### PR TITLE
Move enough vembertech stuff for sst-filters

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,10 @@ if (${SST_BASIC_BLOCKS_BUILD_TESTS})
     add_executable(smoke-test
             tests/smoketest.cpp
             tests/dsp_tests.cpp
+            tests/simd_tests.cpp
             )
     target_link_libraries(smoke-test PUBLIC test-simde ${PROJECT_NAME})
     target_compile_definitions(smoke-test PUBLIC _USE_MATH_DEFINES=1)
+    target_compile_definitions(smoke-test PRIVATE CATCH_CONFIG_DISABLE_EXCEPTIONS=1)
+
 endif ()

--- a/include/sst/basic-blocks/dsp/Clippers.h
+++ b/include/sst/basic-blocks/dsp/Clippers.h
@@ -1,0 +1,71 @@
+/*
+* sst-basic-blocks - a Surge Synth Team product
+*
+* Provides basic tools and blocks for use on the audio thread in
+* synthesis, including basic DSP and modulation functions
+*
+* Copyright 2019 - 2023, Various authors, as described in the github
+* transaction log.
+*
+* sst-basic-blocks is released under the Gnu General Public Licence
+* V3 or later (GPL-3.0-or-later). The license is found in the file
+* "LICENSE" in the root of this repository or at
+* https://www.gnu.org/licenses/gpl-3.0.en.html
+*
+* All source for sst-basic-blocks is available at
+* https://github.com/surge-synthesizer/sst-basic-blocks
+*/
+
+#ifndef SST_BASICBLOCKS_DSP_CLIPPERS_H
+#define SST_BASICBLOCKS_DSP_CLIPPERS_H
+
+namespace sst::basic_blocks::dsp
+{
+
+/**
+ * y = x - (4/27)*x^3,  x in [-1.5 .. 1.5], +/-1 otherwise
+ */
+inline __m128 softclip_ps(__m128 in)
+{
+    const __m128 a = _mm_set1_ps(-4.f / 27.f);
+
+    const __m128 x_min = _mm_set1_ps(-1.5f);
+    const __m128 x_max = _mm_set1_ps(1.5f);
+
+    __m128 x = _mm_max_ps(_mm_min_ps(in, x_max), x_min);
+    __m128 xx = _mm_mul_ps(x, x);
+    __m128 t = _mm_mul_ps(x, a);
+    t = _mm_mul_ps(t, xx);
+    t = _mm_add_ps(t, x);
+
+    return t;
+}
+
+
+/**
+ * y = x - (4/27/8^3)*x^3,  x in [-12 .. 12], +/-12 otherwise
+ */
+inline __m128 softclip8_ps(__m128 in)
+{
+    /*
+     * This constant is - 4/27 / 8^3 so it "scales" the
+     * coefficient but if you look at the plot I don't think
+     * that's quite right - it doesn't have the right smoothness.
+     * But this is only used in one spot - in LPMOOGquad - so
+     * we will just leave it for now
+     */
+    const __m128 a = _mm_set1_ps(-0.00028935185185f);
+
+    const __m128 x_min = _mm_set1_ps(-12.f);
+    const __m128 x_max = _mm_set1_ps(12.f);
+
+    __m128 x = _mm_max_ps(_mm_min_ps(in, x_max), x_min);
+    __m128 xx = _mm_mul_ps(x, x);
+    __m128 t = _mm_mul_ps(x, a);
+    t = _mm_mul_ps(t, xx);
+    t = _mm_add_ps(t, x);
+    return t;
+}
+}
+
+#endif // SURGE_SHAPERS_H

--- a/include/sst/basic-blocks/mechanics/simd-ops.h
+++ b/include/sst/basic-blocks/mechanics/simd-ops.h
@@ -37,6 +37,22 @@ inline float sum_ps_to_float(__m128 x)
     return f;
 }
 
+namespace detail
+{
+inline float i2f_binary_cast(int i)
+{
+    float *f = (float *)&i;
+    return *f;
+}
+}
+
+const __m128 m128_mask_signbit = _mm_set1_ps(detail::i2f_binary_cast(0x80000000));
+const __m128 m128_mask_absval = _mm_set1_ps(detail::i2f_binary_cast(0x7fffffff));
+
+inline __m128 abs_ps(__m128 x) {
+    return _mm_and_ps(x, m128_mask_absval);
+}
+
 } // namespace sst::basic_blocks::block_ops
 
 #endif // SHORTCIRCUIT_SIMD_OPS_H

--- a/tests/dsp_tests.cpp
+++ b/tests/dsp_tests.cpp
@@ -9,6 +9,7 @@
 #include "sst/basic-blocks/dsp/QuadratureOscillators.h"
 #include "sst/basic-blocks/dsp/LanczosResampler.h"
 #include "sst/basic-blocks/dsp/FastMath.h"
+#include "sst/basic-blocks/dsp/Clippers.h"
 
 #include <iostream>
 
@@ -451,4 +452,21 @@ TEST_CASE("Check FastMath Functions", "[dsp]")
             }
         }
     }
+}
+
+TEST_CASE("SoftClip", "[dsp]")
+{
+    float r alignas(16)[4];
+    r[0] = -1.6;
+    r[1] = -0.8;
+    r[2] = 0.6;
+    r[3] = 1.7;
+
+    auto v = _mm_load_ps(r);
+    auto c = sst::basic_blocks::dsp::softclip_ps(v);
+    _mm_store_ps(r, c);
+    REQUIRE(r[0] == Approx(-1.0).margin(0.0001));
+    REQUIRE(r[1] == Approx(-0.8 - 4.f / 27.f * pow(-0.8, 3)).margin(0.0001));
+    REQUIRE(r[2] == Approx(0.6 - 4.f / 27.f * pow(0.6, 3)).margin(0.0001));
+    REQUIRE(r[3] == Approx(1.0).margin(0.0001));
 }

--- a/tests/simd_tests.cpp
+++ b/tests/simd_tests.cpp
@@ -1,0 +1,36 @@
+//
+// Created by Paul Walker on 4/17/23.
+//
+
+#include "catch2.hpp"
+#include "smoke_test_sse.h"
+
+#include "sst/basic-blocks/mechanics/simd-ops.h"
+
+#include <iostream>
+
+TEST_CASE("abs_ps", "[simd]")
+{
+    auto p1 = _mm_set1_ps(13.2);
+    auto p2 = _mm_set1_ps(-142.3);
+    auto ap1 = sst::basic_blocks::mechanics::abs_ps(p1);
+    auto ap2 = sst::basic_blocks::mechanics::abs_ps(p2);
+
+    float res alignas(16)[4];
+    _mm_store_ps(res, ap1);
+    REQUIRE(res[0] == Approx(13.2).margin(0.0001));
+
+    _mm_store_ps(res, ap2);
+    REQUIRE(res[0] == Approx(142.3).margin(0.00001));
+}
+
+TEST_CASE("Sums", "[simd]")
+{
+    float res alignas(16)[4];
+    res[0] = 0.1;
+    res[1] = 0.2;
+    res[2] = 0.3;
+    res[3] = 0.4;
+    auto val = _mm_load_ps(res);
+    REQUIRE(sst::basic_blocks::mechanics::sum_ps_to_float(val) == Approx(1.0).margin(0.00001));
+}


### PR DESCRIPTION
With this diff, sst-filters can remove its copy of basic_dsp.h

Addresses https://github.com/surge-synthesizer/surge/issues/6946