### PR TITLE
More porting from surge

### DIFF
--- a/include/sst/basic-blocks/dsp/CorrelatedNoise.h
+++ b/include/sst/basic-blocks/dsp/CorrelatedNoise.h
@@ -25,8 +25,8 @@
 namespace sst::basic_blocks::dsp
 {
 
-inline float correlated_noise_o2mk2_suppliedrng(float &lastval, float &lastval2, float correlation,
-                                                std::function<float()> &urng)
+inline float correlated_noise_o2mk2_supplied_value(float &lastval, float &lastval2, float correlation,
+                                                const float bipolarUniformRandValue)
 {
     float wf = correlation;
     float wfabs = fabs(wf) * 0.8f;
@@ -43,10 +43,16 @@ inline float correlated_noise_o2mk2_suppliedrng(float &lastval, float &lastval2,
     _mm_store_ss(&m, m1);
     // if (wf>0.f) m *= 1 + wf*8;
 
-    float rand11 = urng();
+    float rand11 = bipolarUniformRandValue;
     lastval2 = rand11 * (1 - wfabs) - wf * lastval2;
     lastval = lastval2 * (1 - wfabs) - wf * lastval;
     return lastval * m;
+}
+
+inline float correlated_noise_o2mk2_suppliedrng(float &lastval, float &lastval2, float correlation,
+                                                std::function<float()> &urng)
+{
+    return correlated_noise_o2mk2_supplied_value(lastval, lastval2, correlation, urng());
 }
 } // namespace sst::basic_blocks::dsp
 #endif // SURGEXTRACK_CORRELATEDNOISE_H

--- a/include/sst/basic-blocks/dsp/Interpolators.h
+++ b/include/sst/basic-blocks/dsp/Interpolators.h
@@ -33,6 +33,11 @@ inline float cubic_ipol(float y0, float y1, float y2, float y3, float mu)
 
     return (a0 * mu * mu2 + a1 * mu2 + a2 * mu + a3);
 }
+
+inline float quad_bspline(float y0, float y1, float y2, float mu)
+{
+    return 0.5f * (y2 * (mu * mu) + y1 * (-2 * mu * mu + 2 * mu + 1) + y0 * (mu * mu - 2 * mu + 1));
+}
 } // namespace sst::basic_blocks::dsp
 
 #endif // SURGEXTRACK_INTERPOLATORS_H

--- a/include/sst/basic-blocks/dsp/QuadratureOscillators.h
+++ b/include/sst/basic-blocks/dsp/QuadratureOscillators.h
@@ -45,6 +45,53 @@ template <typename T = float> struct QuadratureOscillator
     }
 };
 
+/**
+ * The Surge Magic Circle style Oscillator
+ */
+ template <typename T = float> struct SurgeQuadrOsc
+{
+  public:
+    SurgeQuadrOsc()
+    {
+        r = 0;
+        i = -1;
+    }
+
+    inline void set_rate(T w)
+    {
+        dr = cos(w);
+        di = sin(w);
+
+        // normalize vector
+        double n = 1 / sqrt(r * r + i * i);
+        r *= n;
+        i *= n;
+    }
+
+    // API compatability
+    inline void setRate(T w) { set_rate(w); }
+
+    inline void set_phase(T w)
+    {
+        r = sin(w);
+        i = -cos(w);
+    }
+
+    inline void process()
+    {
+        float lr = r, li = i;
+        r = dr * lr - di * li;
+        i = dr * li + di * lr;
+    }
+
+    inline void step() { process(); }
+
+  public:
+    T r, i;
+
+  private:
+    T dr, di;
+};
 } // namespace sst::basic_blocks::dsp
 
 #endif // SHORTCIRCUITXT_QUADRATUREOSCILLATORS_H

--- a/tests/dsp_tests.cpp
+++ b/tests/dsp_tests.cpp
@@ -185,6 +185,29 @@ TEST_CASE("Quadrature Oscillator")
     }
 }
 
+
+TEST_CASE("Surge Quadrature Oscillator")
+{
+    for (const auto omega : {0.04, 0.12, 0.43, 0.97})
+    {
+        DYNAMIC_SECTION("Surge Quadrature omega=" << omega)
+        {
+            auto q = sst::basic_blocks::dsp::SurgeQuadrOsc();
+
+            float p0 = 0;
+            q.setRate(omega);
+            for (int i = 0; i < 200; ++i)
+            {
+                REQUIRE(q.r == Approx(sin(p0)).margin(1e-3));
+                REQUIRE(q.i == Approx(-cos(p0)).margin(1e-3));
+
+                q.step();
+                p0 += omega;
+            }
+        }
+    }
+}
+
 TEST_CASE("LanczosResampler", "[dsp]")
 {
     SECTION("Can Interpolate Sine")


### PR DESCRIPTION
1. Add a new version of CorrelatedNoise so we can work with surge rngs
2. Add quadr bspline to interpolateors
3. port in the surge quadrature oscillator which is subtly different than the vicanek one, and add a test for it