### PR TITLE
Align lipol_sse; run clang-format

### DIFF
--- a/include/sst/basic-blocks/dsp/BlockInterpolators.h
+++ b/include/sst/basic-blocks/dsp/BlockInterpolators.h
@@ -77,9 +77,10 @@ template <int maxBlockSize, bool first_run_checks = true> struct alignas(16) lip
     __m128 zeroUpByQuarters;
     __m128 one, zero;
 
+  public:
     static constexpr int maxRegisters{maxBlockSize >> 2};
-
     int numRegisters{maxBlockSize >> 2};
+    int blockSize{maxBlockSize};
     float blockSizeInv{1.f / blockSize};
     float registerSizeInv{1.f / (blockSize >> 2)};
 
@@ -270,8 +271,6 @@ template <int maxBlockSize, bool first_run_checks = true> struct alignas(16) lip
         blockSizeInv = 1.f / blockSize;
         registerSizeInv = 1.f / (blockSize >> 2);
     }
-
-    int blockSize{maxBlockSize};
 
   private:
     void updateLine()

--- a/include/sst/basic-blocks/dsp/Clippers.h
+++ b/include/sst/basic-blocks/dsp/Clippers.h
@@ -43,7 +43,6 @@ inline __m128 softclip_ps(__m128 in)
     return t;
 }
 
-
 /**
  * y = x - (4/27/8^3)*x^3,  x in [-12 .. 12], +/-12 otherwise
  */
@@ -89,8 +88,7 @@ inline __m128 tanh7_ps(__m128 v)
     return _mm_mul_ps(y, x);
 }
 
-template <size_t blockSize>
-void softclip_block(float *__restrict x)
+template <size_t blockSize> void softclip_block(float *__restrict x)
 {
     for (unsigned int i = 0; i < blockSize; i += 4)
     {
@@ -98,8 +96,7 @@ void softclip_block(float *__restrict x)
     }
 }
 
-template <size_t blockSize>
-void tanh7_block(float *__restrict x)
+template <size_t blockSize> void tanh7_block(float *__restrict x)
 {
     for (unsigned int i = 0; i < blockSize; i += 4)
     {
@@ -107,8 +104,7 @@ void tanh7_block(float *__restrict x)
     }
 }
 
-template<size_t blockSize>
-void hardclip_block(float *x)
+template <size_t blockSize> void hardclip_block(float *x)
 {
     static_assert(!(blockSize & (blockSize - 1)) && blockSize >= 4);
     const __m128 x_min = _mm_set1_ps(-1.0f);
@@ -119,9 +115,7 @@ void hardclip_block(float *x)
     }
 }
 
-
-template<size_t blockSize>
-void hardclip_block8(float *x)
+template <size_t blockSize> void hardclip_block8(float *x)
 {
     static_assert(!(blockSize & (blockSize - 1)) && blockSize >= 4);
     const __m128 x_min = _mm_set1_ps(-8.0f);
@@ -131,6 +125,6 @@ void hardclip_block8(float *x)
         _mm_store_ps(x + i, _mm_max_ps(_mm_min_ps(_mm_load_ps(x + i), x_max), x_min));
     }
 }
-}
+} // namespace sst::basic_blocks::dsp
 
 #endif // SURGE_SHAPERS_H

--- a/include/sst/basic-blocks/dsp/CorrelatedNoise.h
+++ b/include/sst/basic-blocks/dsp/CorrelatedNoise.h
@@ -27,8 +27,9 @@
 namespace sst::basic_blocks::dsp
 {
 
-inline float correlated_noise_o2mk2_supplied_value(float &lastval, float &lastval2, float correlation,
-                                                const float bipolarUniformRandValue)
+inline float correlated_noise_o2mk2_supplied_value(float &lastval, float &lastval2,
+                                                   float correlation,
+                                                   const float bipolarUniformRandValue)
 {
     float wf = correlation;
     float wfabs = fabs(wf) * 0.8f;

--- a/include/sst/basic-blocks/dsp/LanczosResampler.h
+++ b/include/sst/basic-blocks/dsp/LanczosResampler.h
@@ -21,7 +21,6 @@
 #ifndef INCLUDE_SST_BASIC_BLOCKS_DSP_LANCZOSRESAMPLER_H
 #define INCLUDE_SST_BASIC_BLOCKS_DSP_LANCZOSRESAMPLER_H
 
-
 #include <algorithm>
 #include <utility>
 #include <cmath>
@@ -241,5 +240,5 @@ template <int bs> void LanczosResampler<bs>::populateNextBlockSizeOS(float *fL, 
     }
     phaseO += (bs << 1) * dPhaseO;
 }
-}
+} // namespace sst::basic_blocks::dsp
 #endif

--- a/include/sst/basic-blocks/dsp/MidSide.h
+++ b/include/sst/basic-blocks/dsp/MidSide.h
@@ -23,9 +23,8 @@
 
 namespace sst::basic_blocks::dsp
 {
-template<size_t blocksize>
-void encodeMS(float *__restrict L, float *__restrict R,
-              float *__restrict M, float *__restrict S)
+template <size_t blocksize>
+void encodeMS(float *__restrict L, float *__restrict R, float *__restrict M, float *__restrict S)
 {
     for (auto i = 0U; i < blocksize; ++i)
     {
@@ -34,9 +33,8 @@ void encodeMS(float *__restrict L, float *__restrict R,
     }
 }
 
-template<size_t blocksize>
-void decodeMS(float *__restrict M, float *__restrict S,
-              float *__restrict L, float *__restrict R)
+template <size_t blocksize>
+void decodeMS(float *__restrict M, float *__restrict S, float *__restrict L, float *__restrict R)
 {
     for (auto i = 0U; i < blocksize; ++i)
     {
@@ -44,5 +42,5 @@ void decodeMS(float *__restrict M, float *__restrict S,
         R[i] = M[i] - S[i];
     }
 }
-}
+} // namespace sst::basic_blocks::dsp
 #endif // SURGE_MIDSIDE_H

--- a/include/sst/basic-blocks/dsp/QuadratureOscillators.h
+++ b/include/sst/basic-blocks/dsp/QuadratureOscillators.h
@@ -50,7 +50,7 @@ template <typename T = float> struct QuadratureOscillator
 /**
  * The Surge Magic Circle style Oscillator
  */
- template <typename T = float> struct SurgeQuadrOsc
+template <typename T = float> struct SurgeQuadrOsc
 {
   public:
     SurgeQuadrOsc()

--- a/include/sst/basic-blocks/dsp/SSESincDelayLine.h
+++ b/include/sst/basic-blocks/dsp/SSESincDelayLine.h
@@ -34,10 +34,10 @@ namespace sst::basic_blocks::dsp
 template <int COMB_SIZE> // power of two
 struct SSESincDelayLine
 {
-    static_assert(! (COMB_SIZE & (COMB_SIZE-1))); // make sure we are a power of 2
+    static_assert(!(COMB_SIZE & (COMB_SIZE - 1))); // make sure we are a power of 2
     static constexpr int comb_size = COMB_SIZE;
 
-    using stp=tables::SurgeSincTableProvider;
+    using stp = tables::SurgeSincTableProvider;
 
     float buffer alignas(16)[COMB_SIZE + stp::FIRipol_N];
     int wp = 0;
@@ -50,7 +50,10 @@ struct SSESincDelayLine
      * but please make sure that table has lifetime longer than this interpolator, since we take the
      * pointer address of its table
      */
-    SSESincDelayLine(const tables::SurgeSincTableProvider &st) : sinctable(st.sinctable) { clear(); }
+    SSESincDelayLine(const tables::SurgeSincTableProvider &st) : sinctable(st.sinctable)
+    {
+        clear();
+    }
 
     inline void write(float f)
     {
@@ -112,5 +115,5 @@ struct SSESincDelayLine
         wp = 0;
     }
 };
-}
+} // namespace sst::basic_blocks::dsp
 #endif // SURGE_SSESINCDELAYLINE_H

--- a/include/sst/basic-blocks/modulators/ADAREnvelope.h
+++ b/include/sst/basic-blocks/modulators/ADAREnvelope.h
@@ -18,8 +18,6 @@
  * https://github.com/surge-synthesizer/sst-basic-blocks
  */
 
-
-
 #ifndef INCLUDE_SST_BASIC_BLOCKS_MODULATORS_ADARENVELOPE_H
 #define INCLUDE_SST_BASIC_BLOCKS_MODULATORS_ADARENVELOPE_H
 
@@ -38,15 +36,13 @@ namespace sst::basic_blocks::modulators
  * @tparam BLOCK_SIZE Must be a power of 2
  * @tparam RangeProvider Defines the min and max
  */
-template<typename SRProvider, int BLOCK_SIZE, typename RangeProvider = TenSecondRange>
+template <typename SRProvider, int BLOCK_SIZE, typename RangeProvider = TenSecondRange>
 struct ADAREnvelope : DiscreteStagesEnvelope<BLOCK_SIZE, RangeProvider>
 {
     using base_t = DiscreteStagesEnvelope<BLOCK_SIZE, RangeProvider>;
 
     SRProvider *srProvider;
-    ADAREnvelope(SRProvider *s) : srProvider(s)
-    {
-    }
+    ADAREnvelope(SRProvider *s) : srProvider(s) {}
 
     bool isDigital{true};
     bool isGated{false};
@@ -131,11 +127,10 @@ struct ADAREnvelope : DiscreteStagesEnvelope<BLOCK_SIZE, RangeProvider>
                             const bool gateActive)
     {
         processScaledAD(this->rateFrom01(1), this->rateFrom01(d), ashape, dshape, gateActive);
-
     }
 
     inline void processScaledAD(const float a, const float d, const int ashape, const int dshape,
-                        const bool gateActive)
+                                const bool gateActive)
     {
         if (base_t::preBlockCheck())
             return;
@@ -162,7 +157,8 @@ struct ADAREnvelope : DiscreteStagesEnvelope<BLOCK_SIZE, RangeProvider>
             }
             else
             {
-                const float coeff_offset = 2.f - std::log2(srProvider->samplerate * base_t::BLOCK_SIZE_INV);
+                const float coeff_offset =
+                    2.f - std::log2(srProvider->samplerate * base_t::BLOCK_SIZE_INV);
 
                 auto ndc = (v_c1_delayed >= 0.99999f);
                 if (ndc && !discharge)
@@ -231,5 +227,5 @@ struct ADAREnvelope : DiscreteStagesEnvelope<BLOCK_SIZE, RangeProvider>
         base_t::step();
     }
 };
-} // namespace sst::surgext_rack::dsp::envelopes
+} // namespace sst::basic_blocks::modulators
 #endif // RACK_HACK_ADARENVELOPE_H

--- a/include/sst/basic-blocks/modulators/DAHDEnvelope.h
+++ b/include/sst/basic-blocks/modulators/DAHDEnvelope.h
@@ -18,8 +18,6 @@
  * https://github.com/surge-synthesizer/sst-basic-blocks
  */
 
-
-
 #ifndef INCLUDE_SST_BASIC_BLOCKS_MODULATORS_DAHDENVELOPE_H
 #define INCLUDE_SST_BASIC_BLOCKS_MODULATORS_DAHDENVELOPE_H
 
@@ -29,7 +27,6 @@
 
 namespace sst::basic_blocks::modulators
 {
-
 
 /**
  * The ADSR or DAHD envelope provider
@@ -42,7 +39,7 @@ namespace sst::basic_blocks::modulators
  * @tparam BLOCK_SIZE  the block size
  * @tparam RangeProvider - sets mins and maxes
  */
-template<typename SRProvider, int BLOCK_SIZE, typename RangeProvider = TenSecondRange>
+template <typename SRProvider, int BLOCK_SIZE, typename RangeProvider = TenSecondRange>
 struct DAHDEnvelope : DiscreteStagesEnvelope<BLOCK_SIZE, RangeProvider>
 {
     using base_t = DiscreteStagesEnvelope<BLOCK_SIZE, RangeProvider>;
@@ -52,7 +49,6 @@ struct DAHDEnvelope : DiscreteStagesEnvelope<BLOCK_SIZE, RangeProvider>
     {
         onSampleRateChanged();
     }
-
 
     bool isDigital{true};
     float phase{0}, start{0};
@@ -210,9 +206,13 @@ struct DAHDEnvelope : DiscreteStagesEnvelope<BLOCK_SIZE, RangeProvider>
 
         // In this case we only need the coefs in their stage
         float coef_A =
-            !discharge ? powf(2.f, std::min(0.f, coeff_offset - (a * base_t::etScale + base_t::etMin))) : 0;
+            !discharge
+                ? powf(2.f, std::min(0.f, coeff_offset - (a * base_t::etScale + base_t::etMin)))
+                : 0;
         float coef_D =
-            discharge ? powf(2.f, std::min(0.f, coeff_offset - (d * base_t::etScale + base_t::etMin))) : 0;
+            discharge
+                ? powf(2.f, std::min(0.f, coeff_offset - (d * base_t::etScale + base_t::etMin)))
+                : 0;
 
         auto diff_v_a = std::max(0.f, v_attack - v_c1);
         auto diff_v_d = std::min(0.f, v_decay - v_c1);
@@ -274,7 +274,6 @@ struct DAHDEnvelope : DiscreteStagesEnvelope<BLOCK_SIZE, RangeProvider>
 
         base_t::step();
     }
-
 };
-} // namespace sst::surgext_rack::dsp::envelopes
+} // namespace sst::basic_blocks::modulators
 #endif // RACK_HACK_ADARENVELOPE_H

--- a/include/sst/basic-blocks/modulators/DiscreteStagesEnvelope.h
+++ b/include/sst/basic-blocks/modulators/DiscreteStagesEnvelope.h
@@ -195,7 +195,6 @@ template <int BLOCK_SIZE, typename RangeProvider> struct DiscreteStagesEnvelope
     float rateFrom01(float r01) { return r01 * etScale + etMin; }
     float rateTo01(float r) { return (r - etMin) / etScale; }
     float deltaTo01(float d) { return d / etScale; }
-    
 };
 } // namespace sst::basic_blocks::modulators
 

--- a/include/sst/basic-blocks/modulators/SimpleLFO.h
+++ b/include/sst/basic-blocks/modulators/SimpleLFO.h
@@ -18,8 +18,6 @@
  * https://github.com/surge-synthesizer/sst-basic-blocks
  */
 
-
-
 #ifndef INCLUDE_SST_BASIC_BLOCKS_MODULATORS_SIMPLELFO_H
 #define INCLUDE_SST_BASIC_BLOCKS_MODULATORS_SIMPLELFO_H
 
@@ -30,27 +28,26 @@
 #include <cmath>
 #include <cassert>
 
-
 namespace sst::basic_blocks::modulators
 {
 
 // For context on SRProvider see the ADSRDAHD Envelope
-template<typename SRProvider, int BLOCK_SIZE>
-struct SimpleLFO
+template <typename SRProvider, int BLOCK_SIZE> struct SimpleLFO
 {
     SRProvider *srProvider{nullptr};
     std::default_random_engine gen;
     std::uniform_real_distribution<float> distro;
     std::function<float()> urng = []() { return 0; };
 
-    static_assert((BLOCK_SIZE >= 8) & !(BLOCK_SIZE & (BLOCK_SIZE - 1)), "Block size must be power of 2 8 or above.");
-    static constexpr float BLOCK_SIZE_INV{1.f/BLOCK_SIZE};
+    static_assert((BLOCK_SIZE >= 8) & !(BLOCK_SIZE & (BLOCK_SIZE - 1)),
+                  "Block size must be power of 2 8 or above.");
+    static constexpr float BLOCK_SIZE_INV{1.f / BLOCK_SIZE};
 
     float rngState[2]{0, 0};
     float rngHistory[4]{0, 0, 0, 0};
 
     float rngCurrent{0};
-    
+
     SimpleLFO(SRProvider *s, uint32_t seed = rand()) : srProvider(s)
     {
         gen = std::default_random_engine();
@@ -164,7 +161,8 @@ struct SimpleLFO
             {
                 // The deform can push correlated noise out of bounds
                 auto ud = d * 0.8;
-                rngCurrent = dsp::correlated_noise_o2mk2_suppliedrng(rngState[0], rngState[1], ud, urng);
+                rngCurrent =
+                    dsp::correlated_noise_o2mk2_suppliedrng(rngState[0], rngState[1], ud, urng);
 
                 rngHistory[3] = rngHistory[2];
                 rngHistory[2] = rngHistory[1];
@@ -208,7 +206,8 @@ struct SimpleLFO
             target = (phase < (d + 1) * 0.5) ? 1 : -1;
             break;
         case SMOOTH_NOISE:
-            target = dsp::cubic_ipol(rngHistory[3], rngHistory[2], rngHistory[1], rngHistory[0], phase);
+            target =
+                dsp::cubic_ipol(rngHistory[3], rngHistory[2], rngHistory[1], rngHistory[0], phase);
             break;
         case SH_NOISE:
             target = rngCurrent;
@@ -220,7 +219,8 @@ struct SimpleLFO
                 if (urng() > (-d))
                 {
                     // 10 ms triggers according to spec so thats 1% of sample rate
-                    rndTrigCountdown = (int)std::round(0.01 * srProvider->samplerate * BLOCK_SIZE_INV);
+                    rndTrigCountdown =
+                        (int)std::round(0.01 * srProvider->samplerate * BLOCK_SIZE_INV);
                 }
             }
             if (rndTrigCountdown > 0)
@@ -257,11 +257,12 @@ struct SimpleLFO
         }
         lastTarget = target;
     }
-private:
-    SimpleLFO(const SimpleLFO&) = delete;
-    SimpleLFO& operator=(const SimpleLFO&) = delete;
-    SimpleLFO(SimpleLFO&&) = delete;
-    SimpleLFO& operator=(SimpleLFO&&) = delete;
+
+  private:
+    SimpleLFO(const SimpleLFO &) = delete;
+    SimpleLFO &operator=(const SimpleLFO &) = delete;
+    SimpleLFO(SimpleLFO &&) = delete;
+    SimpleLFO &operator=(SimpleLFO &&) = delete;
 };
-} // namespace sst::surgext_rack::dsp::modulators
+} // namespace sst::basic_blocks::modulators
 #endif // RACK_HACK_SIMPLELFO_H

--- a/scripts/fix_file_comments.pl
+++ b/scripts/fix_file_comments.pl
@@ -96,5 +96,6 @@ EOH
         close(IN);
         close(OUT);
         system("mv ${q}.bak ${q}");
+        system("clang-format -i ${q}");
     }
 }

--- a/tests/block_tests.cpp
+++ b/tests/block_tests.cpp
@@ -18,7 +18,6 @@
  * https://github.com/surge-synthesizer/sst-basic-blocks
  */
 
-
 #include "catch2.hpp"
 #include "smoke_test_sse.h"
 
@@ -29,40 +28,40 @@ namespace mech = sst::basic_blocks::mechanics;
 
 TEST_CASE("Clear and Copy", "[block]")
 {
-    SECTION( "64")
+    SECTION("64")
     {
         static constexpr int bs{64};
-        float f alignas(16) [bs];
-        float g alignas(16) [bs];
-        float h alignas(16) [bs];
+        float f alignas(16)[bs];
+        float g alignas(16)[bs];
+        float h alignas(16)[bs];
 
-        for (int i=0; i<bs; ++i)
+        for (int i = 0; i < bs; ++i)
             f[i] = std::sin(i * 0.1);
 
         mech::copy_from_to<bs>(f, g);
-        for (int i=0; i<bs; ++i)
+        for (int i = 0; i < bs; ++i)
             REQUIRE(f[i] == g[i]);
 
         mech::scale_by<bs>(f, g);
-        for (int i=0; i<bs; ++i)
+        for (int i = 0; i < bs; ++i)
             REQUIRE(f[i] * f[i] == g[i]);
 
         mech::clear_block<bs>(g);
-        for (int i=0; i<bs; ++i)
+        for (int i = 0; i < bs; ++i)
             REQUIRE(0 == g[i]);
 
         mech::accumulate_from_to<bs>(f, g);
         mech::accumulate_from_to<bs>(f, g);
-        for (int i=0; i<bs; ++i)
+        for (int i = 0; i < bs; ++i)
             REQUIRE(2 * f[i] == g[i]);
 
         auto am = mech::blockAbsMax<bs>(g);
         int eq{0};
-        for (int i=0; i<bs; ++i)
+        for (int i = 0; i < bs; ++i)
         {
             REQUIRE(std::fabs(g[i]) <= am);
             eq += std::fabs(g[i]) == am;
         }
-        REQUIRE( eq > 0);
+        REQUIRE(eq > 0);
     }
 }

--- a/tests/dsp_tests.cpp
+++ b/tests/dsp_tests.cpp
@@ -48,7 +48,7 @@ TEST_CASE("lipol_sse basic", "[dsp]")
             lip.store_block(where);
             for (int i = 0; i < bs; i++)
             {
-                REQUIRE(where[i] == Approx(prev + (t - prev) / bs * (i+1)).margin(1e-5));
+                REQUIRE(where[i] == Approx(prev + (t - prev) / bs * (i + 1)).margin(1e-5));
             }
             prev = t;
         }
@@ -67,7 +67,7 @@ TEST_CASE("lipol_sse basic", "[dsp]")
             lip.store_block(where);
             for (int i = 0; i < bs; i++)
             {
-                REQUIRE(where[i] == Approx(prev + (t - prev) / bs * (i+1)).margin(1e-5));
+                REQUIRE(where[i] == Approx(prev + (t - prev) / bs * (i + 1)).margin(1e-5));
             }
             prev = t;
         }
@@ -86,7 +86,7 @@ TEST_CASE("lipol_sse basic", "[dsp]")
             lip.store_block(where);
             for (int i = 0; i < bs; i++)
             {
-                REQUIRE(where[i] == Approx(prev + (t - prev) / bs * (i+1)).margin(1e-5));
+                REQUIRE(where[i] == Approx(prev + (t - prev) / bs * (i + 1)).margin(1e-5));
             }
             prev = t;
         }
@@ -106,7 +106,7 @@ TEST_CASE("lipol_sse basic", "[dsp]")
             lip.store_block(where);
             for (int i = 0; i < bs; i++)
             {
-                REQUIRE(where[i] == Approx(prev + (t - prev) / bs * (i+1)).margin(1e-5));
+                REQUIRE(where[i] == Approx(prev + (t - prev) / bs * (i + 1)).margin(1e-5));
             }
             prev = t;
         }
@@ -126,7 +126,7 @@ TEST_CASE("lipol_sse basic", "[dsp]")
             lip.store_block(where);
             for (int i = 0; i < bs; i++)
             {
-                REQUIRE(where[i] == Approx(prev + (t - prev) / bs * (i+1)).margin(1e-5));
+                REQUIRE(where[i] == Approx(prev + (t - prev) / bs * (i + 1)).margin(1e-5));
             }
             prev = t;
         }
@@ -150,7 +150,7 @@ TEST_CASE("lipol_sse multiply_block", "[dsp]")
         lip.multiply_block_to(f, r);
         for (int i = 0; i < bs; i++)
         {
-            auto x = (0.2 + (0.6 - 0.2) / bs * (i+1)) * f[i];
+            auto x = (0.2 + (0.6 - 0.2) / bs * (i + 1)) * f[i];
             REQUIRE(x == Approx(r[i]).margin(1e-5));
         }
     }
@@ -174,7 +174,7 @@ TEST_CASE("lipol_sse fade_block", "[dsp]")
         lip.fade_blocks(f, g, r);
         for (int i = 0; i < bs; i++)
         {
-            auto cx = (0.2 + (0.6 - 0.2) / bs * (i+1));
+            auto cx = (0.2 + (0.6 - 0.2) / bs * (i + 1));
             auto rx = f[i] * (1 - cx) + g[i] * cx;
             REQUIRE(rx == Approx(r[i]).margin(1e-5));
         }
@@ -202,7 +202,6 @@ TEST_CASE("Quadrature Oscillator")
         }
     }
 }
-
 
 TEST_CASE("Surge Quadrature Oscillator")
 {
@@ -513,25 +512,22 @@ TEST_CASE("SoftClip", "[dsp]")
 
 TEST_CASE("SoftClip Block", "[dsp]")
 {
-    float r alignas(16)[32],
-        q alignas(16)[32],
-        h alignas(16)[32],
-        h8 alignas(16)[32],
+    float r alignas(16)[32], q alignas(16)[32], h alignas(16)[32], h8 alignas(16)[32],
         t7 alignas(16)[32];
     for (int i = 0; i < 32; ++i)
     {
         r[i] = rand() * 20.4 / RAND_MAX - 10.0;
     }
-    sst::basic_blocks::mechanics::copy_from_to<32>(r,q);
-    sst::basic_blocks::mechanics::copy_from_to<32>(r,h);
-    sst::basic_blocks::mechanics::copy_from_to<32>(r,h8);
-    sst::basic_blocks::mechanics::copy_from_to<32>(r,t7);
+    sst::basic_blocks::mechanics::copy_from_to<32>(r, q);
+    sst::basic_blocks::mechanics::copy_from_to<32>(r, h);
+    sst::basic_blocks::mechanics::copy_from_to<32>(r, h8);
+    sst::basic_blocks::mechanics::copy_from_to<32>(r, t7);
 
     sst::basic_blocks::dsp::softclip_block<32>(q);
     sst::basic_blocks::dsp::hardclip_block<32>(h);
     sst::basic_blocks::dsp::hardclip_block8<32>(h8);
     sst::basic_blocks::dsp::tanh7_block<32>(t7);
-    for (int i=0; i<32; ++i)
+    for (int i = 0; i < 32; ++i)
     {
         auto sci = std::clamp(r[i], -1.5f, 1.5f);
         auto sc = sci - 4.0 / 27.0 * sci * sci * sci;
@@ -543,9 +539,7 @@ TEST_CASE("SoftClip Block", "[dsp]")
         REQUIRE(t7[i] >= -1);
         REQUIRE(t7[i] <= 1);
     }
-
 }
-
 
 TEST_CASE("Sinc Delay Line", "[dsp]")
 {
@@ -659,8 +653,6 @@ TEST_CASE("Sinc Delay Line", "[dsp]")
     }
 #endif
 }
-
-
 
 TEST_CASE("lipol_ps class", "[dsp]")
 {


### PR DESCRIPTION
Surgo had the great idea that if we add an alignas(16) to lipol_sse we don't need to force align all the usages.

Also run clang format on the code.