### PR TITLE
basic blocks requires _USE_MATH_DEFINES

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,7 @@ set(CMAKE_CXX_STANDARD 17)
 
 add_library(${PROJECT_NAME} INTERFACE)
 target_include_directories(${PROJECT_NAME} INTERFACE include)
+target_compile_definitions(${PROJECT_NAME} INTERFACE _USE_MATH_DEFINES=1)
 
 if (${SST_BASIC_BLOCKS_BUILD_TESTS})
     include(cmake/CPM.cmake)
@@ -39,7 +40,6 @@ if (${SST_BASIC_BLOCKS_BUILD_TESTS})
     endif ()
 
     target_link_libraries(sst-basic-blocks-test PRIVATE fmt ${PROJECT_NAME})
-    target_compile_definitions(sst-basic-blocks-test PUBLIC _USE_MATH_DEFINES=1)
     target_compile_definitions(sst-basic-blocks-test PRIVATE CATCH_CONFIG_DISABLE_EXCEPTIONS=1)
 
 endif ()


### PR DESCRIPTION
so add it as a PUBLIC on the interface