### PR TITLE
DPW Smoothing Strategies

### DIFF
--- a/include/sst/basic-blocks/dsp/Lag.h
+++ b/include/sst/basic-blocks/dsp/Lag.h
@@ -89,8 +89,9 @@ template <class T, bool first_run_checks = true> struct SurgeLag
     T v;
     T target_v;
 
-  private:
     bool first_run;
+
+  private:
     T lp, lpinv;
 };
 } // namespace sst::basic_blocks::dsp


### PR DESCRIPTION
provide 3 smoothing strategies for the DPW oscillators

1. "Lag" basically an LPF on the pitch and pulse width
2. "Block" basically a linear interp, but it requires you to set frequency every block
3. "Direct" no smoothing just direct application of changes.