### PR TITLE
Tables get const accessors

### DIFF
--- a/include/sst/basic-blocks/tables/DbToLinearProvider.h
+++ b/include/sst/basic-blocks/tables/DbToLinearProvider.h
@@ -37,7 +37,7 @@ struct DbToLinearProvider
             table_dB[i] = powf(10.f, 0.05f * ((float)i - 384.f));
         }
     }
-    float dbToLinear(float db)
+    float dbToLinear(float db) const
     {
         db += 384;
         int e = (int)db;

--- a/include/sst/basic-blocks/tables/EqualTuningProvider.h
+++ b/include/sst/basic-blocks/tables/EqualTuningProvider.h
@@ -48,7 +48,7 @@ struct EqualTuningProvider
      * note is float offset from note 69 / A440
      * return is 2^(note * 12), namely frequency / 440.0
      */
-    float note_to_pitch(float note)
+    float note_to_pitch(float note) const
     {
         auto x = std::clamp(note + 256, 1.e-4f, tuning_table_size - (float)1.e-4);
         // x += 256;


### PR DESCRIPTION
no reason for the lookup to not be const. Fix that up!