### PR TITLE
Fix FXModulator; Make lipol less scary

### DIFF
--- a/include/sst/basic-blocks/dsp/BlockInterpolators.h
+++ b/include/sst/basic-blocks/dsp/BlockInterpolators.h
@@ -25,7 +25,7 @@
 
 namespace sst::basic_blocks::dsp
 {
-template <class T, int defaultBlockSize, bool first_run_checks = true> struct lipol
+template <class T, int defaultBlockSize, bool first_run_checks> struct lipol
 {
   public:
     lipol() { reset(); }

--- a/include/sst/basic-blocks/modulators/FXModControl.h
+++ b/include/sst/basic-blocks/modulators/FXModControl.h
@@ -29,7 +29,7 @@
 namespace sst::basic_blocks::modulators
 {
 
-struct FXModControl
+template <int blockSize> struct FXModControl
 {
   public:
     float samplerate{0}, samplerate_inv{0};
@@ -223,8 +223,8 @@ struct FXModControl
     }
 
   private:
-    dsp::lipol<float, true> lfoval{};
-    dsp::lipol<float, true> depth{};
+    dsp::lipol<float, blockSize, true> lfoval{};
+    dsp::lipol<float, blockSize, true> depth{};
     float lfophase;
     float lfosandhtarget;
 

--- a/tests/modulator_tests.cpp
+++ b/tests/modulator_tests.cpp
@@ -26,7 +26,7 @@ namespace smod = sst::basic_blocks::modulators;
 
 TEST_CASE("Mod LFO Is Well Behaved", "[mod]")
 {
-    for (int m = smod::FXModControl::mod_sine; m <= smod::FXModControl::mod_square; ++m)
+    for (int m = smod::FXModControl<32>::mod_sine; m <= smod::FXModControl<32>::mod_square; ++m)
     {
         DYNAMIC_SECTION("Mod Control Bounded For Type " << m)
         {
@@ -37,7 +37,7 @@ TEST_CASE("Mod LFO Is Well Behaved", "[mod]")
                 float depth = 1.0;
 
                 INFO("200 Samples at " << rate << " with po " << phase_offset);
-                smod::FXModControl mc(48000, 1.0 / 48000);
+                smod::FXModControl<32> mc(48000, 1.0 / 48000);
                 for (int s = 0; s < 200; ++s)
                 {
                     mc.pre_process(m, rate, depth, phase_offset);


### PR DESCRIPTION
lipol takes 3 template args and last defaulted
lipol used to take 2 template args in surge with one defaulted so you know that is a very sharp knife

it is also what tripped up the FXModulator block size breaking ensemble but that is now fixed