### PR TITLE
Default the offset B in withExtendFactors to 0

### DIFF
--- a/include/sst/basic-blocks/params/ParamMetadata.h
+++ b/include/sst/basic-blocks/params/ParamMetadata.h
@@ -329,8 +329,8 @@ struct ParamMetaData
         res.canExtend = b;
         return res;
     }
-    // extend is f -> A f + B
-    ParamMetaData withExtendFactors(float A, float B)
+    // extend is val = (A * val) + B
+    ParamMetaData withExtendFactors(float A, float B = 0.f)
     {
         auto res = *this;
         res.exA = A;


### PR DESCRIPTION
So that we can just specify the multiplier A alone if needed.