### PR TITLE
License; Exceptions on MacOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,5 @@
 cmake_minimum_required(VERSION 3.10)
+
 project(sst-basic-blocks VERSION 0.5 LANGUAGES C CXX)
 
 set(CMAKE_CXX_STANDARD 17)
@@ -40,6 +41,11 @@ if (${SST_BASIC_BLOCKS_BUILD_TESTS})
     endif ()
 
     target_link_libraries(sst-basic-blocks-test PRIVATE fmt ${PROJECT_NAME})
-    target_compile_definitions(sst-basic-blocks-test PRIVATE CATCH_CONFIG_DISABLE_EXCEPTIONS=1)
+    if ("${CMAKE_OSX_DEPLOYMENT_TARGET}" VERSION_LESS "10.12")
+        message(STATUS "Deactivating exceptions for ${CMAKE_OSX_DEPLOYMENT_TARGET} catch library")
+        target_compile_definitions(sst-basic-blocks-test PRIVATE CATCH_CONFIG_DISABLE_EXCEPTIONS=1)
+    else()
+        message(STATUS "Keeping Catch exception handling on for more modern macOS")
+    endif()
 
 endif ()

--- a/README.md
+++ b/README.md
@@ -1,6 +1,15 @@
 # sst-basic-blocks
 
-Audio-thread things which aren't oscillators, filters, waveshapers, or fx.
-So modulators, block utilities, interpolators, that sort of thing.
+`sst-basic-blocks` is our base level utility classes for things like parameters, block operations,
+sse helpers, base level dsp, and more. It's the 'bottom of the stack' in the surge libraries.
 
-blah
+## An important note about licensing
+
+`sst-basic-blocks` is largely derived from refactoring surge and other properties which are GPL3
+and as such this library is GPL3. A small number of individual files were developed in a context
+where they are (1) standalone (or can be trivially made standalone by removing a header etc) and
+(2) are useful-in and co-developed-with folks who use them in a non-GPL3 context. As such a few
+individual header files are also available to use in an MIT license context. Those header files
+are explicitly marked in the text of the header file and are listed here also
+
+- include/sst/basic-blocks/dsp/LanczosResampler.h

--- a/include/sst/basic-blocks/dsp/BlockInterpolators.h
+++ b/include/sst/basic-blocks/dsp/BlockInterpolators.h
@@ -12,7 +12,13 @@
  * sst-basic-blocks is released under the GNU General Public Licence v3
  * or later (GPL-3.0-or-later). The license is found in the "LICENSE"
  * file in the root of this repository, or at
- * https://www.gnu.org/licenses/gpl-3.0.en.html
+ * https://www.gnu.org/licenses/gpl-3.0.en.html.
+ *
+ * A very small number of explicitly chosen header files can also be
+ * used in an MIT/BSD context. Please see the README.md file in this
+ * repo or the comments in the individual files. Only headers with an
+ * explicit mention that they are dual licensed may be copied and reused
+ * outside the GPL3 terms.
  *
  * All source in sst-basic-blocks available at
  * https://github.com/surge-synthesizer/sst-basic-blocks

--- a/include/sst/basic-blocks/dsp/Clippers.h
+++ b/include/sst/basic-blocks/dsp/Clippers.h
@@ -12,7 +12,13 @@
  * sst-basic-blocks is released under the GNU General Public Licence v3
  * or later (GPL-3.0-or-later). The license is found in the "LICENSE"
  * file in the root of this repository, or at
- * https://www.gnu.org/licenses/gpl-3.0.en.html
+ * https://www.gnu.org/licenses/gpl-3.0.en.html.
+ *
+ * A very small number of explicitly chosen header files can also be
+ * used in an MIT/BSD context. Please see the README.md file in this
+ * repo or the comments in the individual files. Only headers with an
+ * explicit mention that they are dual licensed may be copied and reused
+ * outside the GPL3 terms.
  *
  * All source in sst-basic-blocks available at
  * https://github.com/surge-synthesizer/sst-basic-blocks

--- a/include/sst/basic-blocks/dsp/CorrelatedNoise.h
+++ b/include/sst/basic-blocks/dsp/CorrelatedNoise.h
@@ -12,7 +12,13 @@
  * sst-basic-blocks is released under the GNU General Public Licence v3
  * or later (GPL-3.0-or-later). The license is found in the "LICENSE"
  * file in the root of this repository, or at
- * https://www.gnu.org/licenses/gpl-3.0.en.html
+ * https://www.gnu.org/licenses/gpl-3.0.en.html.
+ *
+ * A very small number of explicitly chosen header files can also be
+ * used in an MIT/BSD context. Please see the README.md file in this
+ * repo or the comments in the individual files. Only headers with an
+ * explicit mention that they are dual licensed may be copied and reused
+ * outside the GPL3 terms.
  *
  * All source in sst-basic-blocks available at
  * https://github.com/surge-synthesizer/sst-basic-blocks

--- a/include/sst/basic-blocks/dsp/DPWSawPulseOscillator.h
+++ b/include/sst/basic-blocks/dsp/DPWSawPulseOscillator.h
@@ -12,7 +12,13 @@
  * sst-basic-blocks is released under the GNU General Public Licence v3
  * or later (GPL-3.0-or-later). The license is found in the "LICENSE"
  * file in the root of this repository, or at
- * https://www.gnu.org/licenses/gpl-3.0.en.html
+ * https://www.gnu.org/licenses/gpl-3.0.en.html.
+ *
+ * A very small number of explicitly chosen header files can also be
+ * used in an MIT/BSD context. Please see the README.md file in this
+ * repo or the comments in the individual files. Only headers with an
+ * explicit mention that they are dual licensed may be copied and reused
+ * outside the GPL3 terms.
  *
  * All source in sst-basic-blocks available at
  * https://github.com/surge-synthesizer/sst-basic-blocks

--- a/include/sst/basic-blocks/dsp/FastMath.h
+++ b/include/sst/basic-blocks/dsp/FastMath.h
@@ -12,7 +12,13 @@
  * sst-basic-blocks is released under the GNU General Public Licence v3
  * or later (GPL-3.0-or-later). The license is found in the "LICENSE"
  * file in the root of this repository, or at
- * https://www.gnu.org/licenses/gpl-3.0.en.html
+ * https://www.gnu.org/licenses/gpl-3.0.en.html.
+ *
+ * A very small number of explicitly chosen header files can also be
+ * used in an MIT/BSD context. Please see the README.md file in this
+ * repo or the comments in the individual files. Only headers with an
+ * explicit mention that they are dual licensed may be copied and reused
+ * outside the GPL3 terms.
  *
  * All source in sst-basic-blocks available at
  * https://github.com/surge-synthesizer/sst-basic-blocks

--- a/include/sst/basic-blocks/dsp/Interpolators.h
+++ b/include/sst/basic-blocks/dsp/Interpolators.h
@@ -12,7 +12,13 @@
  * sst-basic-blocks is released under the GNU General Public Licence v3
  * or later (GPL-3.0-or-later). The license is found in the "LICENSE"
  * file in the root of this repository, or at
- * https://www.gnu.org/licenses/gpl-3.0.en.html
+ * https://www.gnu.org/licenses/gpl-3.0.en.html.
+ *
+ * A very small number of explicitly chosen header files can also be
+ * used in an MIT/BSD context. Please see the README.md file in this
+ * repo or the comments in the individual files. Only headers with an
+ * explicit mention that they are dual licensed may be copied and reused
+ * outside the GPL3 terms.
  *
  * All source in sst-basic-blocks available at
  * https://github.com/surge-synthesizer/sst-basic-blocks

--- a/include/sst/basic-blocks/dsp/Lag.h
+++ b/include/sst/basic-blocks/dsp/Lag.h
@@ -12,7 +12,13 @@
  * sst-basic-blocks is released under the GNU General Public Licence v3
  * or later (GPL-3.0-or-later). The license is found in the "LICENSE"
  * file in the root of this repository, or at
- * https://www.gnu.org/licenses/gpl-3.0.en.html
+ * https://www.gnu.org/licenses/gpl-3.0.en.html.
+ *
+ * A very small number of explicitly chosen header files can also be
+ * used in an MIT/BSD context. Please see the README.md file in this
+ * repo or the comments in the individual files. Only headers with an
+ * explicit mention that they are dual licensed may be copied and reused
+ * outside the GPL3 terms.
  *
  * All source in sst-basic-blocks available at
  * https://github.com/surge-synthesizer/sst-basic-blocks

--- a/include/sst/basic-blocks/dsp/LanczosResampler.h
+++ b/include/sst/basic-blocks/dsp/LanczosResampler.h
@@ -12,7 +12,13 @@
  * sst-basic-blocks is released under the GNU General Public Licence v3
  * or later (GPL-3.0-or-later). The license is found in the "LICENSE"
  * file in the root of this repository, or at
- * https://www.gnu.org/licenses/gpl-3.0.en.html
+ * https://www.gnu.org/licenses/gpl-3.0.en.html.
+ *
+ * A very small number of explicitly chosen header files can also be
+ * used in an MIT/BSD context. Please see the README.md file in this
+ * repo or the comments in the individual files. Only headers with an
+ * explicit mention that they are dual licensed may be copied and reused
+ * outside the GPL3 terms.
  *
  * All source in sst-basic-blocks available at
  * https://github.com/surge-synthesizer/sst-basic-blocks
@@ -22,25 +28,22 @@
 #define INCLUDE_SST_BASIC_BLOCKS_DSP_LANCZOSRESAMPLER_H
 
 /*
- * A special note on licensing: This file (and only this file)
- * has Paul Walker (baconpaul) as the sole author to date.
+ * A special note on licensing: This file can be re-used either
+ * in a GPL3 or MIT licensing context. See the information in
+ * README.md. If you commit changes to this file, you are also
+ * willing to have it re-used in a GPL3 or MIT/BSD context.
  *
- * In order to make this handy small function based on public
- * information available to a set of open source projects
- * adapting hardware to software, but which are licensed under
- * MIT or BSD or similar licenses, this file and only this file
- * can be used in an MIT/BSD context as well as a GPL3 context, by
- * copying it and modifying it as you see fit.
- *
- * If you do that, you will need to replace the `sum_ps_to_float`
+ * If you do use this in a GPL3 context, you will need to copy,
+ * strip the single include and replace the `sum_ps_to_float`
  * call below with either an hadd if you are SSE3 or higher or
  * an appropriate reduction operator from your toolkit.
  *
  * But basically: Need to resample 48k to variable rate with
  * a small window and want to use this? Go for it!
  *
- * For avoidance of doubt, this license exception only
- * applies to this file.
+ * For avoidance of doubt, this license modification only applies
+ * to the files in this package which have an explicit mention
+ * in the header and which are listed in README.md
  */
 
 #include <algorithm>

--- a/include/sst/basic-blocks/dsp/MidSide.h
+++ b/include/sst/basic-blocks/dsp/MidSide.h
@@ -12,7 +12,13 @@
  * sst-basic-blocks is released under the GNU General Public Licence v3
  * or later (GPL-3.0-or-later). The license is found in the "LICENSE"
  * file in the root of this repository, or at
- * https://www.gnu.org/licenses/gpl-3.0.en.html
+ * https://www.gnu.org/licenses/gpl-3.0.en.html.
+ *
+ * A very small number of explicitly chosen header files can also be
+ * used in an MIT/BSD context. Please see the README.md file in this
+ * repo or the comments in the individual files. Only headers with an
+ * explicit mention that they are dual licensed may be copied and reused
+ * outside the GPL3 terms.
  *
  * All source in sst-basic-blocks available at
  * https://github.com/surge-synthesizer/sst-basic-blocks

--- a/include/sst/basic-blocks/dsp/PanLaws.h
+++ b/include/sst/basic-blocks/dsp/PanLaws.h
@@ -12,7 +12,13 @@
  * sst-basic-blocks is released under the GNU General Public Licence v3
  * or later (GPL-3.0-or-later). The license is found in the "LICENSE"
  * file in the root of this repository, or at
- * https://www.gnu.org/licenses/gpl-3.0.en.html
+ * https://www.gnu.org/licenses/gpl-3.0.en.html.
+ *
+ * A very small number of explicitly chosen header files can also be
+ * used in an MIT/BSD context. Please see the README.md file in this
+ * repo or the comments in the individual files. Only headers with an
+ * explicit mention that they are dual licensed may be copied and reused
+ * outside the GPL3 terms.
  *
  * All source in sst-basic-blocks available at
  * https://github.com/surge-synthesizer/sst-basic-blocks

--- a/include/sst/basic-blocks/dsp/QuadratureOscillators.h
+++ b/include/sst/basic-blocks/dsp/QuadratureOscillators.h
@@ -12,7 +12,13 @@
  * sst-basic-blocks is released under the GNU General Public Licence v3
  * or later (GPL-3.0-or-later). The license is found in the "LICENSE"
  * file in the root of this repository, or at
- * https://www.gnu.org/licenses/gpl-3.0.en.html
+ * https://www.gnu.org/licenses/gpl-3.0.en.html.
+ *
+ * A very small number of explicitly chosen header files can also be
+ * used in an MIT/BSD context. Please see the README.md file in this
+ * repo or the comments in the individual files. Only headers with an
+ * explicit mention that they are dual licensed may be copied and reused
+ * outside the GPL3 terms.
  *
  * All source in sst-basic-blocks available at
  * https://github.com/surge-synthesizer/sst-basic-blocks

--- a/include/sst/basic-blocks/dsp/SSESincDelayLine.h
+++ b/include/sst/basic-blocks/dsp/SSESincDelayLine.h
@@ -12,7 +12,13 @@
  * sst-basic-blocks is released under the GNU General Public Licence v3
  * or later (GPL-3.0-or-later). The license is found in the "LICENSE"
  * file in the root of this repository, or at
- * https://www.gnu.org/licenses/gpl-3.0.en.html
+ * https://www.gnu.org/licenses/gpl-3.0.en.html.
+ *
+ * A very small number of explicitly chosen header files can also be
+ * used in an MIT/BSD context. Please see the README.md file in this
+ * repo or the comments in the individual files. Only headers with an
+ * explicit mention that they are dual licensed may be copied and reused
+ * outside the GPL3 terms.
  *
  * All source in sst-basic-blocks available at
  * https://github.com/surge-synthesizer/sst-basic-blocks

--- a/include/sst/basic-blocks/dsp/SpecialFunctions.h
+++ b/include/sst/basic-blocks/dsp/SpecialFunctions.h
@@ -12,7 +12,13 @@
  * sst-basic-blocks is released under the GNU General Public Licence v3
  * or later (GPL-3.0-or-later). The license is found in the "LICENSE"
  * file in the root of this repository, or at
- * https://www.gnu.org/licenses/gpl-3.0.en.html
+ * https://www.gnu.org/licenses/gpl-3.0.en.html.
+ *
+ * A very small number of explicitly chosen header files can also be
+ * used in an MIT/BSD context. Please see the README.md file in this
+ * repo or the comments in the individual files. Only headers with an
+ * explicit mention that they are dual licensed may be copied and reused
+ * outside the GPL3 terms.
  *
  * All source in sst-basic-blocks available at
  * https://github.com/surge-synthesizer/sst-basic-blocks

--- a/include/sst/basic-blocks/dsp/VUPeak.h
+++ b/include/sst/basic-blocks/dsp/VUPeak.h
@@ -12,7 +12,13 @@
  * sst-basic-blocks is released under the GNU General Public Licence v3
  * or later (GPL-3.0-or-later). The license is found in the "LICENSE"
  * file in the root of this repository, or at
- * https://www.gnu.org/licenses/gpl-3.0.en.html
+ * https://www.gnu.org/licenses/gpl-3.0.en.html.
+ *
+ * A very small number of explicitly chosen header files can also be
+ * used in an MIT/BSD context. Please see the README.md file in this
+ * repo or the comments in the individual files. Only headers with an
+ * explicit mention that they are dual licensed may be copied and reused
+ * outside the GPL3 terms.
  *
  * All source in sst-basic-blocks available at
  * https://github.com/surge-synthesizer/sst-basic-blocks

--- a/include/sst/basic-blocks/mechanics/block-ops.h
+++ b/include/sst/basic-blocks/mechanics/block-ops.h
@@ -12,7 +12,13 @@
  * sst-basic-blocks is released under the GNU General Public Licence v3
  * or later (GPL-3.0-or-later). The license is found in the "LICENSE"
  * file in the root of this repository, or at
- * https://www.gnu.org/licenses/gpl-3.0.en.html
+ * https://www.gnu.org/licenses/gpl-3.0.en.html.
+ *
+ * A very small number of explicitly chosen header files can also be
+ * used in an MIT/BSD context. Please see the README.md file in this
+ * repo or the comments in the individual files. Only headers with an
+ * explicit mention that they are dual licensed may be copied and reused
+ * outside the GPL3 terms.
  *
  * All source in sst-basic-blocks available at
  * https://github.com/surge-synthesizer/sst-basic-blocks

--- a/include/sst/basic-blocks/mechanics/endian-ops.h
+++ b/include/sst/basic-blocks/mechanics/endian-ops.h
@@ -12,7 +12,13 @@
  * sst-basic-blocks is released under the GNU General Public Licence v3
  * or later (GPL-3.0-or-later). The license is found in the "LICENSE"
  * file in the root of this repository, or at
- * https://www.gnu.org/licenses/gpl-3.0.en.html
+ * https://www.gnu.org/licenses/gpl-3.0.en.html.
+ *
+ * A very small number of explicitly chosen header files can also be
+ * used in an MIT/BSD context. Please see the README.md file in this
+ * repo or the comments in the individual files. Only headers with an
+ * explicit mention that they are dual licensed may be copied and reused
+ * outside the GPL3 terms.
  *
  * All source in sst-basic-blocks available at
  * https://github.com/surge-synthesizer/sst-basic-blocks

--- a/include/sst/basic-blocks/mechanics/simd-ops.h
+++ b/include/sst/basic-blocks/mechanics/simd-ops.h
@@ -12,7 +12,13 @@
  * sst-basic-blocks is released under the GNU General Public Licence v3
  * or later (GPL-3.0-or-later). The license is found in the "LICENSE"
  * file in the root of this repository, or at
- * https://www.gnu.org/licenses/gpl-3.0.en.html
+ * https://www.gnu.org/licenses/gpl-3.0.en.html.
+ *
+ * A very small number of explicitly chosen header files can also be
+ * used in an MIT/BSD context. Please see the README.md file in this
+ * repo or the comments in the individual files. Only headers with an
+ * explicit mention that they are dual licensed may be copied and reused
+ * outside the GPL3 terms.
  *
  * All source in sst-basic-blocks available at
  * https://github.com/surge-synthesizer/sst-basic-blocks

--- a/include/sst/basic-blocks/modulators/ADAREnvelope.h
+++ b/include/sst/basic-blocks/modulators/ADAREnvelope.h
@@ -12,7 +12,13 @@
  * sst-basic-blocks is released under the GNU General Public Licence v3
  * or later (GPL-3.0-or-later). The license is found in the "LICENSE"
  * file in the root of this repository, or at
- * https://www.gnu.org/licenses/gpl-3.0.en.html
+ * https://www.gnu.org/licenses/gpl-3.0.en.html.
+ *
+ * A very small number of explicitly chosen header files can also be
+ * used in an MIT/BSD context. Please see the README.md file in this
+ * repo or the comments in the individual files. Only headers with an
+ * explicit mention that they are dual licensed may be copied and reused
+ * outside the GPL3 terms.
  *
  * All source in sst-basic-blocks available at
  * https://github.com/surge-synthesizer/sst-basic-blocks

--- a/include/sst/basic-blocks/modulators/ADSREnvelope.h
+++ b/include/sst/basic-blocks/modulators/ADSREnvelope.h
@@ -12,7 +12,13 @@
  * sst-basic-blocks is released under the GNU General Public Licence v3
  * or later (GPL-3.0-or-later). The license is found in the "LICENSE"
  * file in the root of this repository, or at
- * https://www.gnu.org/licenses/gpl-3.0.en.html
+ * https://www.gnu.org/licenses/gpl-3.0.en.html.
+ *
+ * A very small number of explicitly chosen header files can also be
+ * used in an MIT/BSD context. Please see the README.md file in this
+ * repo or the comments in the individual files. Only headers with an
+ * explicit mention that they are dual licensed may be copied and reused
+ * outside the GPL3 terms.
  *
  * All source in sst-basic-blocks available at
  * https://github.com/surge-synthesizer/sst-basic-blocks

--- a/include/sst/basic-blocks/modulators/AHDSRShapedSC.h
+++ b/include/sst/basic-blocks/modulators/AHDSRShapedSC.h
@@ -12,7 +12,13 @@
  * sst-basic-blocks is released under the GNU General Public Licence v3
  * or later (GPL-3.0-or-later). The license is found in the "LICENSE"
  * file in the root of this repository, or at
- * https://www.gnu.org/licenses/gpl-3.0.en.html
+ * https://www.gnu.org/licenses/gpl-3.0.en.html.
+ *
+ * A very small number of explicitly chosen header files can also be
+ * used in an MIT/BSD context. Please see the README.md file in this
+ * repo or the comments in the individual files. Only headers with an
+ * explicit mention that they are dual licensed may be copied and reused
+ * outside the GPL3 terms.
  *
  * All source in sst-basic-blocks available at
  * https://github.com/surge-synthesizer/sst-basic-blocks

--- a/include/sst/basic-blocks/modulators/DAHDEnvelope.h
+++ b/include/sst/basic-blocks/modulators/DAHDEnvelope.h
@@ -12,7 +12,13 @@
  * sst-basic-blocks is released under the GNU General Public Licence v3
  * or later (GPL-3.0-or-later). The license is found in the "LICENSE"
  * file in the root of this repository, or at
- * https://www.gnu.org/licenses/gpl-3.0.en.html
+ * https://www.gnu.org/licenses/gpl-3.0.en.html.
+ *
+ * A very small number of explicitly chosen header files can also be
+ * used in an MIT/BSD context. Please see the README.md file in this
+ * repo or the comments in the individual files. Only headers with an
+ * explicit mention that they are dual licensed may be copied and reused
+ * outside the GPL3 terms.
  *
  * All source in sst-basic-blocks available at
  * https://github.com/surge-synthesizer/sst-basic-blocks

--- a/include/sst/basic-blocks/modulators/DiscreteStagesEnvelope.h
+++ b/include/sst/basic-blocks/modulators/DiscreteStagesEnvelope.h
@@ -12,7 +12,13 @@
  * sst-basic-blocks is released under the GNU General Public Licence v3
  * or later (GPL-3.0-or-later). The license is found in the "LICENSE"
  * file in the root of this repository, or at
- * https://www.gnu.org/licenses/gpl-3.0.en.html
+ * https://www.gnu.org/licenses/gpl-3.0.en.html.
+ *
+ * A very small number of explicitly chosen header files can also be
+ * used in an MIT/BSD context. Please see the README.md file in this
+ * repo or the comments in the individual files. Only headers with an
+ * explicit mention that they are dual licensed may be copied and reused
+ * outside the GPL3 terms.
  *
  * All source in sst-basic-blocks available at
  * https://github.com/surge-synthesizer/sst-basic-blocks

--- a/include/sst/basic-blocks/modulators/SimpleLFO.h
+++ b/include/sst/basic-blocks/modulators/SimpleLFO.h
@@ -12,7 +12,13 @@
  * sst-basic-blocks is released under the GNU General Public Licence v3
  * or later (GPL-3.0-or-later). The license is found in the "LICENSE"
  * file in the root of this repository, or at
- * https://www.gnu.org/licenses/gpl-3.0.en.html
+ * https://www.gnu.org/licenses/gpl-3.0.en.html.
+ *
+ * A very small number of explicitly chosen header files can also be
+ * used in an MIT/BSD context. Please see the README.md file in this
+ * repo or the comments in the individual files. Only headers with an
+ * explicit mention that they are dual licensed may be copied and reused
+ * outside the GPL3 terms.
  *
  * All source in sst-basic-blocks available at
  * https://github.com/surge-synthesizer/sst-basic-blocks

--- a/include/sst/basic-blocks/params/ParamMetadata.h
+++ b/include/sst/basic-blocks/params/ParamMetadata.h
@@ -12,7 +12,13 @@
  * sst-basic-blocks is released under the GNU General Public Licence v3
  * or later (GPL-3.0-or-later). The license is found in the "LICENSE"
  * file in the root of this repository, or at
- * https://www.gnu.org/licenses/gpl-3.0.en.html
+ * https://www.gnu.org/licenses/gpl-3.0.en.html.
+ *
+ * A very small number of explicitly chosen header files can also be
+ * used in an MIT/BSD context. Please see the README.md file in this
+ * repo or the comments in the individual files. Only headers with an
+ * explicit mention that they are dual licensed may be copied and reused
+ * outside the GPL3 terms.
  *
  * All source in sst-basic-blocks available at
  * https://github.com/surge-synthesizer/sst-basic-blocks

--- a/include/sst/basic-blocks/tables/DbToLinearProvider.h
+++ b/include/sst/basic-blocks/tables/DbToLinearProvider.h
@@ -12,7 +12,13 @@
  * sst-basic-blocks is released under the GNU General Public Licence v3
  * or later (GPL-3.0-or-later). The license is found in the "LICENSE"
  * file in the root of this repository, or at
- * https://www.gnu.org/licenses/gpl-3.0.en.html
+ * https://www.gnu.org/licenses/gpl-3.0.en.html.
+ *
+ * A very small number of explicitly chosen header files can also be
+ * used in an MIT/BSD context. Please see the README.md file in this
+ * repo or the comments in the individual files. Only headers with an
+ * explicit mention that they are dual licensed may be copied and reused
+ * outside the GPL3 terms.
  *
  * All source in sst-basic-blocks available at
  * https://github.com/surge-synthesizer/sst-basic-blocks

--- a/include/sst/basic-blocks/tables/EqualTuningProvider.h
+++ b/include/sst/basic-blocks/tables/EqualTuningProvider.h
@@ -12,7 +12,13 @@
  * sst-basic-blocks is released under the GNU General Public Licence v3
  * or later (GPL-3.0-or-later). The license is found in the "LICENSE"
  * file in the root of this repository, or at
- * https://www.gnu.org/licenses/gpl-3.0.en.html
+ * https://www.gnu.org/licenses/gpl-3.0.en.html.
+ *
+ * A very small number of explicitly chosen header files can also be
+ * used in an MIT/BSD context. Please see the README.md file in this
+ * repo or the comments in the individual files. Only headers with an
+ * explicit mention that they are dual licensed may be copied and reused
+ * outside the GPL3 terms.
  *
  * All source in sst-basic-blocks available at
  * https://github.com/surge-synthesizer/sst-basic-blocks

--- a/include/sst/basic-blocks/tables/SincTableProvider.h
+++ b/include/sst/basic-blocks/tables/SincTableProvider.h
@@ -12,7 +12,13 @@
  * sst-basic-blocks is released under the GNU General Public Licence v3
  * or later (GPL-3.0-or-later). The license is found in the "LICENSE"
  * file in the root of this repository, or at
- * https://www.gnu.org/licenses/gpl-3.0.en.html
+ * https://www.gnu.org/licenses/gpl-3.0.en.html.
+ *
+ * A very small number of explicitly chosen header files can also be
+ * used in an MIT/BSD context. Please see the README.md file in this
+ * repo or the comments in the individual files. Only headers with an
+ * explicit mention that they are dual licensed may be copied and reused
+ * outside the GPL3 terms.
  *
  * All source in sst-basic-blocks available at
  * https://github.com/surge-synthesizer/sst-basic-blocks

--- a/include/sst/basic-blocks/tables/TwoToTheXProvider.h
+++ b/include/sst/basic-blocks/tables/TwoToTheXProvider.h
@@ -12,7 +12,13 @@
  * sst-basic-blocks is released under the GNU General Public Licence v3
  * or later (GPL-3.0-or-later). The license is found in the "LICENSE"
  * file in the root of this repository, or at
- * https://www.gnu.org/licenses/gpl-3.0.en.html
+ * https://www.gnu.org/licenses/gpl-3.0.en.html.
+ *
+ * A very small number of explicitly chosen header files can also be
+ * used in an MIT/BSD context. Please see the README.md file in this
+ * repo or the comments in the individual files. Only headers with an
+ * explicit mention that they are dual licensed may be copied and reused
+ * outside the GPL3 terms.
  *
  * All source in sst-basic-blocks available at
  * https://github.com/surge-synthesizer/sst-basic-blocks

--- a/scripts/fix_file_comments.pl
+++ b/scripts/fix_file_comments.pl
@@ -39,7 +39,13 @@ sub findfiles
  * sst-basic-blocks is released under the GNU General Public Licence v3
  * or later (GPL-3.0-or-later). The license is found in the "LICENSE"
  * file in the root of this repository, or at
- * https://www.gnu.org/licenses/gpl-3.0.en.html
+ * https://www.gnu.org/licenses/gpl-3.0.en.html.
+ *
+ * A very small number of explicitly chosen header files can also be
+ * used in an MIT/BSD context. Please see the README.md file in this
+ * repo or the comments in the individual files. Only headers with an
+ * explicit mention that they are dual licensed may be copied and reused
+ * outside the GPL3 terms.
  *
  * All source in sst-basic-blocks available at
  * https://github.com/surge-synthesizer/sst-basic-blocks

--- a/tests/block_tests.cpp
+++ b/tests/block_tests.cpp
@@ -12,7 +12,13 @@
  * sst-basic-blocks is released under the GNU General Public Licence v3
  * or later (GPL-3.0-or-later). The license is found in the "LICENSE"
  * file in the root of this repository, or at
- * https://www.gnu.org/licenses/gpl-3.0.en.html
+ * https://www.gnu.org/licenses/gpl-3.0.en.html.
+ *
+ * A very small number of explicitly chosen header files can also be
+ * used in an MIT/BSD context. Please see the README.md file in this
+ * repo or the comments in the individual files. Only headers with an
+ * explicit mention that they are dual licensed may be copied and reused
+ * outside the GPL3 terms.
  *
  * All source in sst-basic-blocks available at
  * https://github.com/surge-synthesizer/sst-basic-blocks

--- a/tests/dsp_tests.cpp
+++ b/tests/dsp_tests.cpp
@@ -12,7 +12,13 @@
  * sst-basic-blocks is released under the GNU General Public Licence v3
  * or later (GPL-3.0-or-later). The license is found in the "LICENSE"
  * file in the root of this repository, or at
- * https://www.gnu.org/licenses/gpl-3.0.en.html
+ * https://www.gnu.org/licenses/gpl-3.0.en.html.
+ *
+ * A very small number of explicitly chosen header files can also be
+ * used in an MIT/BSD context. Please see the README.md file in this
+ * repo or the comments in the individual files. Only headers with an
+ * explicit mention that they are dual licensed may be copied and reused
+ * outside the GPL3 terms.
  *
  * All source in sst-basic-blocks available at
  * https://github.com/surge-synthesizer/sst-basic-blocks

--- a/tests/param_tests.cpp
+++ b/tests/param_tests.cpp
@@ -12,7 +12,13 @@
  * sst-basic-blocks is released under the GNU General Public Licence v3
  * or later (GPL-3.0-or-later). The license is found in the "LICENSE"
  * file in the root of this repository, or at
- * https://www.gnu.org/licenses/gpl-3.0.en.html
+ * https://www.gnu.org/licenses/gpl-3.0.en.html.
+ *
+ * A very small number of explicitly chosen header files can also be
+ * used in an MIT/BSD context. Please see the README.md file in this
+ * repo or the comments in the individual files. Only headers with an
+ * explicit mention that they are dual licensed may be copied and reused
+ * outside the GPL3 terms.
  *
  * All source in sst-basic-blocks available at
  * https://github.com/surge-synthesizer/sst-basic-blocks

--- a/tests/run_envelopes.cpp
+++ b/tests/run_envelopes.cpp
@@ -12,7 +12,13 @@
  * sst-basic-blocks is released under the GNU General Public Licence v3
  * or later (GPL-3.0-or-later). The license is found in the "LICENSE"
  * file in the root of this repository, or at
- * https://www.gnu.org/licenses/gpl-3.0.en.html
+ * https://www.gnu.org/licenses/gpl-3.0.en.html.
+ *
+ * A very small number of explicitly chosen header files can also be
+ * used in an MIT/BSD context. Please see the README.md file in this
+ * repo or the comments in the individual files. Only headers with an
+ * explicit mention that they are dual licensed may be copied and reused
+ * outside the GPL3 terms.
  *
  * All source in sst-basic-blocks available at
  * https://github.com/surge-synthesizer/sst-basic-blocks

--- a/tests/simd_tests.cpp
+++ b/tests/simd_tests.cpp
@@ -12,7 +12,13 @@
  * sst-basic-blocks is released under the GNU General Public Licence v3
  * or later (GPL-3.0-or-later). The license is found in the "LICENSE"
  * file in the root of this repository, or at
- * https://www.gnu.org/licenses/gpl-3.0.en.html
+ * https://www.gnu.org/licenses/gpl-3.0.en.html.
+ *
+ * A very small number of explicitly chosen header files can also be
+ * used in an MIT/BSD context. Please see the README.md file in this
+ * repo or the comments in the individual files. Only headers with an
+ * explicit mention that they are dual licensed may be copied and reused
+ * outside the GPL3 terms.
  *
  * All source in sst-basic-blocks available at
  * https://github.com/surge-synthesizer/sst-basic-blocks

--- a/tests/smoke_test_sse.h
+++ b/tests/smoke_test_sse.h
@@ -12,7 +12,13 @@
  * sst-basic-blocks is released under the GNU General Public Licence v3
  * or later (GPL-3.0-or-later). The license is found in the "LICENSE"
  * file in the root of this repository, or at
- * https://www.gnu.org/licenses/gpl-3.0.en.html
+ * https://www.gnu.org/licenses/gpl-3.0.en.html.
+ *
+ * A very small number of explicitly chosen header files can also be
+ * used in an MIT/BSD context. Please see the README.md file in this
+ * repo or the comments in the individual files. Only headers with an
+ * explicit mention that they are dual licensed may be copied and reused
+ * outside the GPL3 terms.
  *
  * All source in sst-basic-blocks available at
  * https://github.com/surge-synthesizer/sst-basic-blocks

--- a/tests/smoketest.cpp
+++ b/tests/smoketest.cpp
@@ -12,7 +12,13 @@
  * sst-basic-blocks is released under the GNU General Public Licence v3
  * or later (GPL-3.0-or-later). The license is found in the "LICENSE"
  * file in the root of this repository, or at
- * https://www.gnu.org/licenses/gpl-3.0.en.html
+ * https://www.gnu.org/licenses/gpl-3.0.en.html.
+ *
+ * A very small number of explicitly chosen header files can also be
+ * used in an MIT/BSD context. Please see the README.md file in this
+ * repo or the comments in the individual files. Only headers with an
+ * explicit mention that they are dual licensed may be copied and reused
+ * outside the GPL3 terms.
  *
  * All source in sst-basic-blocks available at
  * https://github.com/surge-synthesizer/sst-basic-blocks

--- a/tests/table_tests.cpp
+++ b/tests/table_tests.cpp
@@ -12,7 +12,13 @@
  * sst-basic-blocks is released under the GNU General Public Licence v3
  * or later (GPL-3.0-or-later). The license is found in the "LICENSE"
  * file in the root of this repository, or at
- * https://www.gnu.org/licenses/gpl-3.0.en.html
+ * https://www.gnu.org/licenses/gpl-3.0.en.html.
+ *
+ * A very small number of explicitly chosen header files can also be
+ * used in an MIT/BSD context. Please see the README.md file in this
+ * repo or the comments in the individual files. Only headers with an
+ * explicit mention that they are dual licensed may be copied and reused
+ * outside the GPL3 terms.
  *
  * All source in sst-basic-blocks available at
  * https://github.com/surge-synthesizer/sst-basic-blocks


### PR DESCRIPTION
- Clarify that the package is GPL3 but that also a few files are available to be copied in an MIT fashion
- Change the CATCH exception override to not be used if OSX deployment greater than 10.12