### PR TITLE
Param Scaling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,7 @@ if (${SST_BASIC_BLOCKS_BUILD_TESTS})
     endif ()
 
     target_link_libraries(sst-basic-blocks-test PRIVATE fmt ${PROJECT_NAME})
+
     if ((DEFINED ${CMAKE_OSX_DEPLOYMENT_TARGET}) AND ("${CMAKE_OSX_DEPLOYMENT_TARGET}" VERSION_LESS "10.12"))
         message(STATUS "Deactivating exceptions for ${CMAKE_OSX_DEPLOYMENT_TARGET} catch library")
         target_compile_definitions(sst-basic-blocks-test PRIVATE CATCH_CONFIG_DISABLE_EXCEPTIONS=1)


### PR DESCRIPTION
Add associated APIs and tests for miliseconds; modify envelope time to use it by default.

Addresses surge-synthesizer/surge#7424 Make it so Parammetadata can have an alternate scale above