### PR TITLE
A generalized mod matrix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,7 @@ if (${SST_BASIC_BLOCKS_BUILD_TESTS})
             tests/param_tests.cpp
             tests/run_envelopes.cpp
             tests/modulator_tests.cpp
+            tests/mod_matrix_tests.cpp
             )
     if (NOT TARGET simde)
         message(STATUS "Importing SIMDE with CPM")

--- a/include/sst/basic-blocks/mod-matrix/ModMatrix.h
+++ b/include/sst/basic-blocks/mod-matrix/ModMatrix.h
@@ -1,0 +1,298 @@
+/*
+ * sst-basic-blocks - an open source library of core audio utilities
+ * built by Surge Synth Team.
+ *
+ * Provides a collection of tools useful on the audio thread for blocks,
+ * modulation, etc... or useful for adapting code to multiple environments.
+ *
+ * Copyright 2023, various authors, as described in the GitHub
+ * transaction log. Parts of this code are derived from similar
+ * functions original in Surge or ShortCircuit.
+ *
+ * sst-basic-blocks is released under the GNU General Public Licence v3
+ * or later (GPL-3.0-or-later). The license is found in the "LICENSE"
+ * file in the root of this repository, or at
+ * https://www.gnu.org/licenses/gpl-3.0.en.html.
+ *
+ * A very small number of explicitly chosen header files can also be
+ * used in an MIT/BSD context. Please see the README.md file in this
+ * repo or the comments in the individual files. Only headers with an
+ * explicit mention that they are dual licensed may be copied and reused
+ * outside the GPL3 terms.
+ *
+ * All source in sst-basic-blocks available at
+ * https://github.com/surge-synthesizer/sst-basic-blocks
+ */
+
+#ifndef INCLUDE_SST_BASIC_BLOCKS_MOD_MATRIX_MODMATRIX_H
+#define INCLUDE_SST_BASIC_BLOCKS_MOD_MATRIX_MODMATRIX_H
+
+#include <optional>
+#include <array>
+#include <cassert>
+#include <unordered_map>
+#include <unordered_set>
+
+#include <iostream>
+#include "ModMatrixDetails.h"
+
+/*
+ * This is an implementation of a relatively genericised mod matrix which
+ * has the form of 'source1 * source2 * depth' if active. The values for the
+ * target and source ar a template trait which have a value semantic and can
+ * hash and operator==.
+ *
+ * The matrix provides pointers to values at runtime and binds to input target
+ * base value and source pointers. It's assumed these pointers live longer
+ * than the matrix.
+ */
+namespace sst::basic_blocks::mod_matrix
+{
+template <typename ModMatrixTraits>
+struct RoutingTable : details::CheckModMatrixConstraints<ModMatrixTraits>
+{
+    using TR = ModMatrixTraits;
+
+    struct Routing
+    {
+        bool active{true};
+        std::optional<typename TR::SourceIdentifier> source{std::nullopt};
+        std::optional<typename TR::SourceIdentifier> sourceVia{std::nullopt};
+        std::optional<typename TR::TargetIdentifier> target{std::nullopt};
+        std::optional<typename TR::CurveIdentifier> curve{std::nullopt};
+
+        float depth{0};
+
+        typename TR::RoutingExtraPayload extraPayload;
+    };
+};
+
+template <typename ModMatrixTraits>
+struct ModMatrix : details::CheckModMatrixConstraints<ModMatrixTraits>
+{
+    using TR = ModMatrixTraits;
+
+    std::unordered_map<typename TR::TargetIdentifier, float &> baseValues;
+    void bindTargetBaseValue(const typename TR::TargetIdentifier &t, float &f)
+    {
+        baseValues.insert_or_assign(t, f);
+    }
+
+    std::unordered_map<typename TR::SourceIdentifier, float &> sourceValues;
+    void bindSourceValue(const typename TR::SourceIdentifier &s, float &f)
+    {
+        sourceValues.insert_or_assign(s, f);
+    }
+
+    static constexpr bool canSelfModulate{details::has_isTargetModMatrixDepth<TR>::value};
+    bool isTargetModMatrixDepth(typename TR::TargetIdentifier &t)
+    {
+        if constexpr (canSelfModulate)
+        {
+            return TR::isTargetModMatrixDepth(t);
+        }
+        else
+        {
+            return false;
+        }
+    }
+};
+
+template <typename ModMatrixTraits> struct FixedLengthRoutingTable : RoutingTable<ModMatrixTraits>
+{
+    using TR = ModMatrixTraits;
+    using RT = RoutingTable<ModMatrixTraits>;
+    static_assert(std::is_same<decltype(TR::FixedMatrixSize), const size_t>::value);
+
+    std::array<typename RT::Routing, TR::FixedMatrixSize> routes{};
+    std::unordered_map<typename TR::TargetIdentifier, bool> isOutputMapped;
+    std::unordered_map<typename TR::TargetIdentifier, size_t> targetToOutputIndex;
+    std::unordered_map<typename TR::SourceIdentifier, bool> isSourceUsed;
+
+    // fixed API for changing the mod matrix in increasing completeness
+    void updateDepthAt(size_t position, float depth)
+    {
+        assert(position < TR::FixedMatrixSize);
+        routes[position].depth = depth;
+    }
+
+    void updateActiveAt(size_t position, bool act)
+    {
+        assert(position < TR::FixedMatrixSize);
+        routes[position].active = act;
+    }
+
+    void updateRoutingAt(size_t position, const typename TR::SourceIdentifier &source,
+                         const typename TR::TargetIdentifier &target, float depth)
+    {
+        assert(position < TR::FixedMatrixSize);
+        routes[position].source = source;
+        routes[position].target = target;
+        routes[position].depth = depth;
+
+        updateRoutingState();
+    }
+    void updateRoutingAt(size_t position, const typename TR::SourceIdentifier &source,
+                         const typename TR::SourceIdentifier &sourceVia,
+                         const typename TR::CurveIdentifier &curve,
+                         const typename TR::TargetIdentifier &target, float depth)
+    {
+        assert(position < TR::FixedMatrixSize);
+        routes[position].source = source;
+        routes[position].sourceVia = sourceVia;
+        routes[position].curve = curve;
+        routes[position].target = target;
+        routes[position].depth = depth;
+
+        updateRoutingState();
+    }
+
+    void updateRoutingState()
+    {
+        isOutputMapped.clear();
+        isSourceUsed.clear();
+        targetToOutputIndex.clear();
+        size_t outIdx{0};
+        for (auto &r : routes)
+        {
+            if (!r.source.has_value() && !r.target.has_value())
+                continue;
+
+            isOutputMapped[*r.target] = true;
+            isSourceUsed[*r.source] = true;
+            if (r.sourceVia.has_value())
+                isSourceUsed[*(r.sourceVia)] = true;
+
+            if (targetToOutputIndex.find(*r.target) == targetToOutputIndex.end())
+            {
+                targetToOutputIndex.insert_or_assign(*r.target, outIdx);
+                outIdx++;
+            }
+        }
+    }
+};
+
+template <typename ModMatrixTraits> struct FixedMatrix : ModMatrix<ModMatrixTraits>
+{
+    using TR = ModMatrixTraits;
+    using PT = ModMatrix<ModMatrixTraits>;
+    using RT = FixedLengthRoutingTable<ModMatrixTraits>;
+    using RoutingTable = RT;
+
+    RoutingTable routingTable;
+
+    std::array<float, TR::FixedMatrixSize> matrixOutputs{};
+
+    struct RoutingValuePointers
+    {
+        bool *active{nullptr};
+        float *source{nullptr}, *sourceVia{nullptr}, *depth{nullptr}, *target{nullptr};
+        float depthScale{1.f};
+    };
+    std::array<RoutingValuePointers, TR::FixedMatrixSize> routingValuePointers{};
+
+    void prepare(RT rt)
+    {
+        this->routingTable = rt;
+        this->routingTable.updateRoutingState();
+
+        int idx{0};
+        std::unordered_set<typename TR::TargetIdentifier> depthMaps;
+        for (auto &r : routingTable.routes)
+        {
+            if (!r.source.has_value() && !r.target.has_value())
+                continue;
+
+            auto &rv = routingValuePointers[idx];
+            rv = RoutingValuePointers();
+            idx++;
+            if (this->sourceValues.find(*r.source) == this->sourceValues.end())
+            {
+                continue;
+            }
+            if (this->routingTable.targetToOutputIndex.find(*r.target) ==
+                this->routingTable.targetToOutputIndex.end())
+            {
+                continue;
+            }
+
+            rv.source = &this->sourceValues.at(*r.source);
+            if (r.sourceVia.has_value())
+                rv.sourceVia = &this->sourceValues.at(*(r.sourceVia));
+
+            if constexpr (ModMatrix<TR>::canSelfModulate)
+            {
+                if (TR::isTargetModMatrixDepth(*(r.target)))
+                {
+                    depthMaps.insert(*(r.target));
+                }
+            }
+
+            rv.depthScale = 1.f;
+            rv.depth = &r.depth;
+            rv.active = &r.active;
+
+            rv.target = &matrixOutputs[routingTable.targetToOutputIndex.at(*r.target)];
+        }
+
+        if constexpr (ModMatrix<TR>::canSelfModulate)
+        {
+            for (auto m : depthMaps)
+            {
+                auto depthIndex = TR::getTargetModMatrixElement(m);
+                assert(depthIndex < routingValuePointers.size());
+                routingValuePointers[depthIndex].depth =
+                    &matrixOutputs[routingTable.targetToOutputIndex.at(m)];
+                this->baseValues.insert_or_assign(m, this->routingTable.routes[depthIndex].depth);
+            }
+        }
+    }
+
+    void process()
+    {
+        std::fill(matrixOutputs.begin(), matrixOutputs.end(), 0.f);
+
+        for (const auto &[tgt, outIdx] : routingTable.targetToOutputIndex)
+        {
+            matrixOutputs[outIdx] = this->baseValues.at(tgt);
+        }
+        for (auto r : routingValuePointers)
+        {
+            if (r.active && !(*r.active))
+                continue;
+
+            if (!r.source || !r.target)
+                continue;
+
+            float sourceViaVal{1.f};
+            if (r.sourceVia)
+                sourceViaVal = *r.sourceVia;
+
+            *(r.target) += *(r.source) * *(r.depth) * r.depthScale * sourceViaVal;
+        }
+    }
+
+    const float *getTargetValuePointer(const typename TR::TargetIdentifier &s) const
+    {
+        auto f = routingTable.isOutputMapped.find(s);
+        if (f == routingTable.isOutputMapped.end() || !f->second)
+        {
+            return &this->baseValues.at(s);
+        }
+        else
+        {
+            return &matrixOutputs[routingTable.targetToOutputIndex.at(s)];
+        }
+    }
+    float getTargetValue(const typename TR::TargetIdentifier &s) const
+    {
+        auto p = getTargetValuePointer(s);
+        if (p)
+            return *p;
+        return 0;
+    }
+};
+
+} // namespace sst::basic_blocks::mod_matrix
+
+#endif // SHORTCIRCUITXT_MODMATRIX_H

--- a/include/sst/basic-blocks/mod-matrix/ModMatrixDetails.h
+++ b/include/sst/basic-blocks/mod-matrix/ModMatrixDetails.h
@@ -1,0 +1,106 @@
+/*
+ * sst-basic-blocks - an open source library of core audio utilities
+ * built by Surge Synth Team.
+ *
+ * Provides a collection of tools useful on the audio thread for blocks,
+ * modulation, etc... or useful for adapting code to multiple environments.
+ *
+ * Copyright 2023, various authors, as described in the GitHub
+ * transaction log. Parts of this code are derived from similar
+ * functions original in Surge or ShortCircuit.
+ *
+ * sst-basic-blocks is released under the GNU General Public Licence v3
+ * or later (GPL-3.0-or-later). The license is found in the "LICENSE"
+ * file in the root of this repository, or at
+ * https://www.gnu.org/licenses/gpl-3.0.en.html.
+ *
+ * A very small number of explicitly chosen header files can also be
+ * used in an MIT/BSD context. Please see the README.md file in this
+ * repo or the comments in the individual files. Only headers with an
+ * explicit mention that they are dual licensed may be copied and reused
+ * outside the GPL3 terms.
+ *
+ * All source in sst-basic-blocks available at
+ * https://github.com/surge-synthesizer/sst-basic-blocks
+ */
+
+#ifndef INCLUDE_SST_BASIC_BLOCKS_MOD_MATRIX_MODMATRIXDETAILS_H
+#define INCLUDE_SST_BASIC_BLOCKS_MOD_MATRIX_MODMATRIXDETAILS_H
+
+#include <type_traits>
+
+namespace sst::basic_blocks::mod_matrix::details
+{
+
+// Thanks again jatin!
+#define HAS_MEMBER(M)                                                                              \
+    template <typename T> class has_##M                                                            \
+    {                                                                                              \
+        using No = uint8_t;                                                                        \
+        using Yes = uint64_t;                                                                      \
+        static_assert(sizeof(No) != sizeof(Yes));                                                  \
+        template <typename C> static Yes test(decltype(C::M) *);                                   \
+        template <typename C> static No test(...);                                                 \
+                                                                                                   \
+      public:                                                                                      \
+        enum                                                                                       \
+        {                                                                                          \
+            value = sizeof(test<T>(nullptr)) == sizeof(Yes)                                        \
+        };                                                                                         \
+    };
+
+HAS_MEMBER(isTargetModMatrixDepth)
+HAS_MEMBER(getTargetModMatrixElement)
+#undef HAS_MEMBER
+
+// And thanks StackOverflow!
+struct detailTypeNo
+{
+};
+template <typename T, typename Arg> detailTypeNo operator==(const T &, const Arg &);
+
+template <typename T, typename Arg = T> struct has_operator_equal
+{
+    enum
+    {
+        value = !std::is_same<decltype(*(T *)(0) == *(Arg *)(0)), detailTypeNo>::value
+    };
+};
+
+template <typename TR> struct CheckModMatrixConstraints
+{
+    static_assert(std::is_constructible<typename TR::SourceIdentifier>::value,
+                  "Source Identifier must be constructable");
+    static_assert(std::is_constructible<std::hash<typename TR::SourceIdentifier>>::value,
+                  "Source Identifier must implement std::hash");
+    static_assert(has_operator_equal<typename TR::SourceIdentifier>::value,
+                  "Source Identifier must implement operator ==");
+
+    static_assert(std::is_constructible<typename TR::TargetIdentifier>::value,
+                  "Target Identifier must be constructable");
+    static_assert(std::is_constructible<std::hash<typename TR::TargetIdentifier>>::value,
+                  "Target Identifier must implement std::hash");
+    static_assert(has_operator_equal<typename TR::TargetIdentifier>::value,
+                  "Target Identifier must implement operator ==");
+
+    static_assert(std::is_constructible<typename TR::CurveIdentifier>::value,
+                  "Curve Identifier must be constructable");
+    static_assert(std::is_constructible<std::hash<typename TR::CurveIdentifier>>::value,
+                  "Curve Identifier must implement std::hash");
+    static_assert(has_operator_equal<typename TR::CurveIdentifier>::value,
+                  "Curve Identifier must implement operator ==");
+
+    static_assert(std::is_same<decltype(TR::IsFixedMatrix), const bool>::value,
+                  "Configuration must define IsFixedMatrix const bool");
+
+    static_assert(std::is_constructible<typename TR::RoutingExtraPayload>::value,
+                  "RoutingExtraPayload must be a constructible type");
+
+    // Self Modulation
+    static_assert(!has_isTargetModMatrixDepth<TR>::value ||
+                      (TR::IsFixedMatrix && has_getTargetModMatrixElement<TR>::value),
+                  "Self-targeting requires fixed matrix with getTargetModMatrixElement for now");
+};
+} // namespace sst::basic_blocks::mod_matrix::details
+
+#endif // SHORTCIRCUITXT_MODMATRIXDETAILS_H

--- a/tests/mod_matrix_tests.cpp
+++ b/tests/mod_matrix_tests.cpp
@@ -1,0 +1,349 @@
+/*
+ * sst-basic-blocks - an open source library of core audio utilities
+ * built by Surge Synth Team.
+ *
+ * Provides a collection of tools useful on the audio thread for blocks,
+ * modulation, etc... or useful for adapting code to multiple environments.
+ *
+ * Copyright 2023, various authors, as described in the GitHub
+ * transaction log. Parts of this code are derived from similar
+ * functions original in Surge or ShortCircuit.
+ *
+ * sst-basic-blocks is released under the GNU General Public Licence v3
+ * or later (GPL-3.0-or-later). The license is found in the "LICENSE"
+ * file in the root of this repository, or at
+ * https://www.gnu.org/licenses/gpl-3.0.en.html.
+ *
+ * A very small number of explicitly chosen header files can also be
+ * used in an MIT/BSD context. Please see the README.md file in this
+ * repo or the comments in the individual files. Only headers with an
+ * explicit mention that they are dual licensed may be copied and reused
+ * outside the GPL3 terms.
+ *
+ * All source in sst-basic-blocks available at
+ * https://github.com/surge-synthesizer/sst-basic-blocks
+ */
+
+#include "sst/basic-blocks/mod-matrix/ModMatrix.h"
+#include <cassert>
+#include "catch2.hpp"
+
+using namespace sst::basic_blocks::mod_matrix;
+
+struct BldConfig
+{
+    using SourceIdentifier = int;
+    using TargetIdentifier = int;
+    using CurveIdentifier = int;
+
+    using RoutingExtraPayload = int;
+
+    static constexpr bool IsFixedMatrix{false};
+};
+TEST_CASE("Construct", "[mod-matrix]") { ModMatrix<BldConfig> m; }
+
+struct Config
+{
+    struct SourceIdentifier
+    {
+        enum SI
+        {
+            FOO,
+            BAR,
+            HOOTIE
+        } src{FOO};
+        int index0{0};
+        int index1{0};
+
+        bool operator==(const SourceIdentifier &other) const
+        {
+            return src == other.src && index0 == other.index0 && index1 == other.index1;
+        }
+    };
+
+    struct TargetIdentifier
+    {
+        int baz{0};
+        uint32_t nm{};
+        int16_t depthPosition{-1};
+
+        bool operator==(const TargetIdentifier &other) const
+        {
+            return baz == other.baz && nm == other.nm && depthPosition == other.depthPosition;
+        }
+    };
+
+    using CurveIdentifier = int;
+
+    static bool isTargetModMatrixDepth(const TargetIdentifier &t) { return t.depthPosition >= 0; }
+    static size_t getTargetModMatrixElement(const TargetIdentifier &t)
+    {
+        assert(isTargetModMatrixDepth(t));
+        return (size_t)t.depthPosition;
+    }
+
+    using RoutingExtraPayload = int;
+
+    static constexpr bool IsFixedMatrix{true};
+    static constexpr size_t FixedMatrixSize{16};
+};
+
+template <> struct std::hash<Config::SourceIdentifier>
+{
+    std::size_t operator()(const Config::SourceIdentifier &s) const noexcept
+    {
+        auto h1 = std::hash<int>{}((int)s.src);
+        auto h2 = std::hash<int>{}((int)s.index0);
+        auto h3 = std::hash<int>{}((int)s.index1);
+        return h1 ^ (h2 << 1) ^ (h3 << 2);
+    }
+};
+
+template <> struct std::hash<Config::TargetIdentifier>
+{
+    std::size_t operator()(const Config::TargetIdentifier &s) const noexcept
+    {
+        auto h1 = std::hash<int>{}((int)s.baz);
+        auto h2 = std::hash<uint32_t>{}((int)s.nm);
+
+        return h1 ^ (h2 << 1);
+    }
+};
+
+TEST_CASE("Configure and Bind", "[mod-matrix]")
+{
+    FixedMatrix<Config> m;
+    FixedMatrix<Config>::RoutingTable rt;
+
+    auto barS = Config::SourceIdentifier{Config::SourceIdentifier::SI::BAR, 2, 3};
+    auto fooS = Config::SourceIdentifier{Config::SourceIdentifier::SI::FOO};
+
+    auto tg3T = Config::TargetIdentifier{3};
+    auto tg3PT = Config::TargetIdentifier{3, 'facd'};
+
+    float barSVal{1.1}, fooSVal{2.3};
+    m.bindSourceValue(barS, barSVal);
+    m.bindSourceValue(fooS, fooSVal);
+
+    float t3V{0.2}, t3PV{0.3};
+    m.bindTargetBaseValue(tg3T, t3V);
+    m.bindTargetBaseValue(tg3PT, t3PV);
+
+    m.prepare(rt);
+
+    m.process();
+
+    INFO("Absent modulation the base values should just shine through")
+    REQUIRE(m.getTargetValue(tg3T) == t3V);
+    REQUIRE(m.getTargetValue(tg3PT) == t3PV);
+
+    t3V = 0.5;
+    t3PV = -0.1;
+
+    m.process();
+
+    REQUIRE(m.getTargetValue(tg3T) == t3V);
+    REQUIRE(m.getTargetValue(tg3PT) == t3PV);
+}
+
+TEST_CASE("Configure Bind and Route", "[mod-matrix]")
+{
+    FixedMatrix<Config> m;
+    FixedMatrix<Config>::RoutingTable rt;
+
+    auto barS = Config::SourceIdentifier{Config::SourceIdentifier::SI::BAR, 2, 3};
+    auto fooS = Config::SourceIdentifier{Config::SourceIdentifier::SI::FOO};
+
+    auto tg3T = Config::TargetIdentifier{3};
+    auto tg3PT = Config::TargetIdentifier{3, 'facd'};
+
+    float barSVal{1.1}, fooSVal{2.3};
+    m.bindSourceValue(barS, barSVal);
+    m.bindSourceValue(fooS, fooSVal);
+
+    float t3V{0.2}, t3PV{0.3};
+    m.bindTargetBaseValue(tg3T, t3V);
+    m.bindTargetBaseValue(tg3PT, t3PV);
+
+    rt.updateRoutingAt(0, barS, tg3T, 0.5);
+    rt.updateRoutingAt(1, fooS, tg3PT, -0.5);
+
+    m.prepare(rt);
+
+    m.process();
+
+    INFO("Absent modulation the base values should just shine through")
+    REQUIRE(m.getTargetValue(tg3T) == Approx(t3V + 0.5 * barSVal).margin(1e-5));
+    REQUIRE(m.getTargetValue(tg3PT) == Approx(t3PV - 0.5 * fooSVal).margin(1e-5));
+
+    t3V = 0.5;
+    t3PV = -0.1;
+
+    m.process();
+
+    REQUIRE(m.getTargetValue(tg3T) == Approx(t3V + 0.5 * barSVal).margin(1e-5));
+    REQUIRE(m.getTargetValue(tg3PT) == Approx(t3PV - 0.5 * fooSVal).margin(1e-5));
+}
+
+TEST_CASE("Configure Bind and Route Pointer Get API", "[mod-matrix]")
+{
+    FixedMatrix<Config> m;
+    FixedMatrix<Config>::RoutingTable rt;
+
+    auto barS = Config::SourceIdentifier{Config::SourceIdentifier::SI::BAR, 2, 3};
+    auto fooS = Config::SourceIdentifier{Config::SourceIdentifier::SI::FOO};
+
+    auto tg3T = Config::TargetIdentifier{3};
+    auto tg3PT = Config::TargetIdentifier{3, 'facd'};
+
+    float barSVal{1.1}, fooSVal{2.3};
+    m.bindSourceValue(barS, barSVal);
+    m.bindSourceValue(fooS, fooSVal);
+
+    float t3V{0.2}, t3PV{0.3};
+    m.bindTargetBaseValue(tg3T, t3V);
+    m.bindTargetBaseValue(tg3PT, t3PV);
+
+    rt.updateRoutingAt(0, barS, tg3T, 0.5);
+    rt.updateRoutingAt(1, fooS, tg3PT, -0.5);
+
+    m.prepare(rt);
+
+    m.process();
+
+    auto t3P = m.getTargetValuePointer(tg3T);
+    auto t3PP = m.getTargetValuePointer(tg3PT);
+
+    INFO("Absent modulation the base values should just shine through")
+    REQUIRE(t3P);
+    REQUIRE(t3PP);
+    REQUIRE(*t3P == Approx(t3V + 0.5 * barSVal).margin(1e-5));
+    REQUIRE(*t3PP == Approx(t3PV - 0.5 * fooSVal).margin(1e-5));
+
+    t3V = 0.5;
+    t3PV = -0.1;
+
+    m.process();
+
+    REQUIRE(*t3P == Approx(t3V + 0.5 * barSVal).margin(1e-5));
+    REQUIRE(*t3PP == Approx(t3PV - 0.5 * fooSVal).margin(1e-5));
+}
+
+TEST_CASE("Modulate Depth", "[mod-matrix]")
+{
+    FixedMatrix<Config> m;
+    FixedMatrix<Config>::RoutingTable rt;
+
+    auto barS = Config::SourceIdentifier{Config::SourceIdentifier::SI::BAR, 2, 3};
+    auto depS = Config::SourceIdentifier{Config::SourceIdentifier::SI::BAR, 17, 3};
+
+    auto tgDepth = Config::TargetIdentifier{1, 'fowq', 1};
+    auto tg3T = Config::TargetIdentifier{3};
+
+    float barSVal{1.1}, depVal{0.f};
+    m.bindSourceValue(barS, barSVal);
+    m.bindSourceValue(depS, depVal);
+
+    float t3V{0.2};
+    m.bindTargetBaseValue(tg3T, t3V);
+
+    rt.updateRoutingAt(0, depS, tgDepth, 0.2);
+    rt.updateRoutingAt(1, barS, tg3T, 0.5);
+
+    m.prepare(rt);
+
+    m.process();
+
+    auto t3P = m.getTargetValuePointer(tg3T);
+    REQUIRE(*(m.routingValuePointers[1].depth) == depVal * 0.2 + 0.5);
+
+    REQUIRE(t3P);
+    REQUIRE(*t3P == Approx(t3V + (0.5 + 0.2 * depVal) * barSVal).margin(1e-5));
+
+    t3V = 0.5;
+    depVal = 0.12;
+
+    m.process();
+    REQUIRE(*t3P == Approx(t3V + (0.5 + 0.2 * depVal) * barSVal).margin(1e-5));
+}
+
+TEST_CASE("Routing Activation", "[mod-matrix]")
+{
+    FixedMatrix<Config> m;
+    FixedMatrix<Config>::RoutingTable rt;
+
+    auto barS = Config::SourceIdentifier{Config::SourceIdentifier::SI::BAR, 2, 3};
+    auto fooS = Config::SourceIdentifier{Config::SourceIdentifier::SI::FOO};
+
+    auto tg3T = Config::TargetIdentifier{3};
+    auto tg3PT = Config::TargetIdentifier{3, 'facd'};
+
+    float barSVal{1.1}, fooSVal{2.3};
+    m.bindSourceValue(barS, barSVal);
+    m.bindSourceValue(fooS, fooSVal);
+
+    float t3V{0.2}, t3PV{0.3};
+    m.bindTargetBaseValue(tg3T, t3V);
+    m.bindTargetBaseValue(tg3PT, t3PV);
+
+    rt.updateRoutingAt(0, barS, tg3T, 0.5);
+    rt.updateRoutingAt(1, fooS, tg3PT, -0.5);
+
+    m.prepare(rt);
+
+    m.process();
+
+    auto t3P = m.getTargetValuePointer(tg3T);
+    auto t3PP = m.getTargetValuePointer(tg3PT);
+
+    INFO("Absent modulation the base values should just shine through")
+    REQUIRE(t3P);
+    REQUIRE(t3PP);
+    REQUIRE(*t3P == Approx(t3V + 0.5 * barSVal).margin(1e-5));
+    REQUIRE(*t3PP == Approx(t3PV - 0.5 * fooSVal).margin(1e-5));
+
+    m.routingTable.routes[0].active = false;
+    m.process();
+
+    REQUIRE(*t3P == Approx(t3V).margin(1e-5));
+    REQUIRE(*t3PP == Approx(t3PV - 0.5 * fooSVal).margin(1e-5));
+}
+
+TEST_CASE("Routing Via", "[mod-matrix]")
+{
+    FixedMatrix<Config> m;
+    FixedMatrix<Config>::RoutingTable rt;
+
+    auto barS = Config::SourceIdentifier{Config::SourceIdentifier::SI::BAR, 2, 3};
+    auto fooS = Config::SourceIdentifier{Config::SourceIdentifier::SI::FOO};
+
+    auto tg3T = Config::TargetIdentifier{3};
+
+    float barSVal{1.1}, fooSVal{2.3};
+    m.bindSourceValue(barS, barSVal);
+    m.bindSourceValue(fooS, fooSVal);
+
+    float t3V{0.2}, t3PV{0.3};
+    m.bindTargetBaseValue(tg3T, t3V);
+
+    // bind with a 'via'
+    rt.updateRoutingAt(0, barS, fooS, {}, tg3T, 0.5);
+
+    m.prepare(rt);
+
+    m.process();
+
+    auto t3P = m.getTargetValuePointer(tg3T);
+
+    INFO("Absent modulation the base values should just shine through")
+    REQUIRE(t3P);
+    REQUIRE(*t3P == Approx(t3V + 0.5 * barSVal * fooSVal).margin(1e-5));
+
+    fooSVal = 0.48;
+    m.process();
+    REQUIRE(*t3P == Approx(t3V + 0.5 * barSVal * fooSVal).margin(1e-5));
+
+    barSVal = 0.298;
+    m.process();
+    REQUIRE(*t3P == Approx(t3V + 0.5 * barSVal * fooSVal).margin(1e-5));
+}


### PR DESCRIPTION
Structures for a generalized output = base + source * via * depth style mod matrix, in this case with the fixed row case implemented and tested, using poitner semantics to values and outputs, with template parameterized identifiers. And a test for same.