### PR TITLE
RNG and LFO get ctor overloads

### DIFF
--- a/include/sst/basic-blocks/dsp/RNG.h
+++ b/include/sst/basic-blocks/dsp/RNG.h
@@ -46,6 +46,10 @@ struct RNG
     {
     }
 
+    void reseedWithClock() { g.seed(std::chrono::system_clock::now().time_since_epoch().count()); }
+
+    void reseed(uint32_t seed) { g.seed(seed); }
+
     inline float unif01() { return z1(g); }
     inline float unifPM1() { return pm1(g); }
     inline float unif(const float min, const float max) { return min + unif01() * (max - min); }

--- a/include/sst/basic-blocks/dsp/RNG.h
+++ b/include/sst/basic-blocks/dsp/RNG.h
@@ -40,6 +40,12 @@ struct RNG
     {
     }
 
+    RNG(uint32_t seed)
+        : g(seed), dg(525600 + 8675309), pm1(-1.f, 1.f), z1(0.f, 1.f), gauss(0.f, .33333f),
+          u32(0, 0xFFFFFFFF)
+    {
+    }
+
     inline float unif01() { return z1(g); }
     inline float unifPM1() { return pm1(g); }
     inline float unif(const float min, const float max) { return min + unif01() * (max - min); }
@@ -66,8 +72,8 @@ struct RNG
     inline float forDisplay() { return pm1(dg); }
 
   private:
-    std::minstd_rand g;  // clock-seeded audio-thread generator
-    std::minstd_rand dg; // fixed-seed ui-thread generator (used by SimpleLFO)
+    std::minstd_rand g;  // clock-seeded audio-thread gen
+    std::minstd_rand dg; // fixed-seed ui-thread gen (used by SimpleLFO)
     std::uniform_real_distribution<float> pm1, z1;
     std::normal_distribution<float> gauss;
     std::uniform_int_distribution<uint32_t> u32;

--- a/include/sst/basic-blocks/modulators/SimpleLFO.h
+++ b/include/sst/basic-blocks/modulators/SimpleLFO.h
@@ -54,6 +54,23 @@ template <typename SRProvider, int BLOCK_SIZE> struct SimpleLFO
 
     float rngCurrent{0};
 
+    SimpleLFO(SRProvider *s, sst::basic_blocks::dsp::RNG &extRng) : srProvider(s)
+    {
+        rng = &extRng;
+        urng = [this]() -> float { return rng.unifPM1(); };
+
+        for (int i = 0; i < BLOCK_SIZE; ++i)
+            outputBlock[i] = 0;
+
+        rngState[0] = urng();
+        rngState[1] = urng();
+        for (int i = 0; i < 4; ++i)
+        {
+            rngCurrent = dsp::correlated_noise_o2mk2_suppliedrng(rngState[0], rngState[1], 0, urng);
+            rngHistory[3 - i] = rngCurrent;
+        }
+    }
+
     SimpleLFO(SRProvider *s) : srProvider(s)
     {
         urng = [this]() -> float { return rng.unifPM1(); };

--- a/include/sst/basic-blocks/modulators/SimpleLFO.h
+++ b/include/sst/basic-blocks/modulators/SimpleLFO.h
@@ -71,6 +71,7 @@ template <typename SRProvider, int BLOCK_SIZE> struct SimpleLFO
         }
     }
 
+    [[deprecated("Use the two-arg constructor with an external RNG")]] 
     SimpleLFO(SRProvider *s) : srProvider(s), objrngRef(objrng)
     {
         objrng.reseedWithClock();

--- a/tests/smoketest.cpp
+++ b/tests/smoketest.cpp
@@ -43,6 +43,8 @@
 #include "sst/basic-blocks/modulators/AHDSRShapedSC.h"
 #include "sst/basic-blocks/modulators/SimpleLFO.h"
 
+#include "sst/basic-blocks/dsp/RNG.h"
+
 #include <memory>
 #include "sst/basic-blocks/mechanics/block-ops.h"
 #include "sst/basic-blocks/mechanics/endian-ops.h"
@@ -69,6 +71,10 @@ int main(int argc, char **argv)
     ad.processScaledAD(0, 0, 0, 0, false);
     auto lf = sst::basic_blocks::modulators::SimpleLFO<SampleSRProvider, 16>(srp.get());
     lf.process_block(0, 0, 0);
+
+    sst::basic_blocks::dsp::RNG rngA, rngB(2112);
+    auto lfer = sst::basic_blocks::modulators::SimpleLFO<SampleSRProvider, 16>(srp.get(), rngB);
+    lfer.process_block(0, 0, 0);
 
     float f[8], g[8];
     sst::basic_blocks::mechanics::accumulate_from_to<8>(f, g);


### PR DESCRIPTION
RNG gets a constructor with a seed arg, simpleLFO gets one with an RNG& arg