### PR TITLE
Fix a sign error in the EXP_SCALE format on C

### DIFF
--- a/include/sst/basic-blocks/modulators/AHDSRShapedSC.h
+++ b/include/sst/basic-blocks/modulators/AHDSRShapedSC.h
@@ -67,7 +67,7 @@ struct AHDSRShapedSC : DiscreteStagesEnvelope<BLOCK_SIZE, RangeProvider>
             {
                 double x = 1.0 * i / (expLutSize - 1);
                 auto timeInSeconds =
-                    (std::exp(RangeProvider::A + x * (RangeProvider::B - RangeProvider::A)) -
+                    (std::exp(RangeProvider::A + x * (RangeProvider::B - RangeProvider::A)) +
                      RangeProvider::C) /
                     RangeProvider::D;
                 auto invTime = 1.0 / timeInSeconds;

--- a/include/sst/basic-blocks/params/ParamMetadata.h
+++ b/include/sst/basic-blocks/params/ParamMetadata.h
@@ -1086,11 +1086,11 @@ inline std::optional<float> ParamMetaData::valueFromString(std::string_view v, s
                 }
             }
 
-            // OK so its R = exp(A + X (B-A)) - C)/D
-            // D R + C = exp(A + X (B-a))
-            // log(DR + C) = A + X (B-A)
-            // (log (DR + C) - A) / (B - A) = X
-            auto drc = std::max(svD * r + svC, 0.00000001f);
+            // OK so its R = exp(A + X (B-A)) + C)/D
+            // D R - C = exp(A + X (B-a))
+            // log(DR - C) = A + X (B-A)
+            // (log (DR - C) - A) / (B - A) = X
+            auto drc = std::max(svD * r - svC, 0.00000001f);
             auto xv = (std::log(drc) - svA) / (svB - svA);
 
             return xv;


### PR DESCRIPTION
Is it +C or -C? Well it's +C but C < 0 is the consistent answer, so apply that everywhere.