### PR TITLE
Fix AHDSR stage progression to decay where skipAttack is true

### DIFF
--- a/include/sst/basic-blocks/modulators/AHDSRShapedSC.h
+++ b/include/sst/basic-blocks/modulators/AHDSRShapedSC.h
@@ -195,6 +195,7 @@ struct AHDSRShapedSC : DiscreteStagesEnvelope<BLOCK_SIZE, RangeProvider>
         case base_t::s_attack:
         {
             phase += dPhase(a);
+            
             if (phase > 1)
             {
                 if (h > 0)
@@ -216,19 +217,26 @@ struct AHDSRShapedSC : DiscreteStagesEnvelope<BLOCK_SIZE, RangeProvider>
         break;
         case base_t::s_hold:
         {
-            phase += dPhase(h);
-
-            target = 1;
-            if (phase > 1)
+            if (h == 0)
             {
                 stage = base_t::s_decay;
-                phase -= 1.f;
             }
+            else
+            {
+                phase += dPhase(h);
+                if (phase > 1)
+                {
+                    stage = base_t::s_decay;
+                    phase -= 1.f;
+                }
+            }
+            target = 1;
         }
         break;
         case base_t::s_decay:
         {
             phase += dPhase(d);
+            
             if (phase > 1)
             {
                 stage = base_t::s_sustain;

--- a/include/sst/basic-blocks/modulators/AHDSRShapedSC.h
+++ b/include/sst/basic-blocks/modulators/AHDSRShapedSC.h
@@ -195,7 +195,6 @@ struct AHDSRShapedSC : DiscreteStagesEnvelope<BLOCK_SIZE, RangeProvider>
         case base_t::s_attack:
         {
             phase += dPhase(a);
-            
             if (phase > 1)
             {
                 if (h > 0)
@@ -224,27 +223,34 @@ struct AHDSRShapedSC : DiscreteStagesEnvelope<BLOCK_SIZE, RangeProvider>
             else
             {
                 phase += dPhase(h);
+                target = 1;
+
                 if (phase > 1)
                 {
                     stage = base_t::s_decay;
                     phase -= 1.f;
                 }
             }
-            target = 1;
         }
         break;
         case base_t::s_decay:
         {
-            phase += dPhase(d);
-            
-            if (phase > 1)
+            if (d == 0)
             {
                 stage = base_t::s_sustain;
-                target = s;
             }
             else
             {
-                target = (1.0 - kernel(phase, dshape)) * (1.0 - s) + s;
+                phase += dPhase(d);
+                if (phase > 1)
+                {
+                    stage = base_t::s_sustain;
+                    target = s;
+                }
+                else
+                {
+                    target = (1.0 - kernel(phase, dshape)) * (1.0 - s) + s;
+                }
             }
         }
         break;


### PR DESCRIPTION
Related to: https://github.com/surge-synthesizer/shortcircuit-xt/issues/1389
Regression identified in: https://github.com/surge-synthesizer/sst-basic-blocks/commit/bc80e645b6cc4862892c5fa64b48a519beb144e3

Tested w/ in-situ build.

Note: This only addresses the A+H==0 case.  This does **not** address the envelope length calculation being seemingly too short.