### PR TITLE
Fix an AHDRSSC release stage bug

### DIFF
--- a/include/sst/basic-blocks/modulators/AHDSRShapedSC.h
+++ b/include/sst/basic-blocks/modulators/AHDSRShapedSC.h
@@ -202,7 +202,14 @@ struct AHDSRShapedSC : DiscreteStagesEnvelope<BLOCK_SIZE, RangeProvider>
             else
             {
                 stage = base_t::s_release;
-                releaseStartValue = this->outputCache[0];
+                if (needsCurve)
+                {
+                    releaseStartValue = this->outputCache[0];
+                }
+                else
+                {
+                    releaseStartValue = this->outBlock0;
+                }
                 phase = 0;
             }
         }


### PR DESCRIPTION
In 8196b9a80214464f6ff56117b7dae0648e5f646a I optimized the AHDSR to not generate the full block if not needed. This broke the release stage. In SC we only saw this in EG2 which is why it lingered. Anyway fix that.