### PR TITLE
Fix an index error in a (previously unused) Lanczos sampler function

### DIFF
--- a/include/sst/basic-blocks/dsp/LanczosResampler.h
+++ b/include/sst/basic-blocks/dsp/LanczosResampler.h
@@ -255,7 +255,7 @@ template <int bs> void LanczosResampler<bs>::populateNextBlockSize(float *fL, fl
     {
         read(r0 - i * dPhaseO, fL[i], fR[i]);
     }
-    phaseO += (bs << 1) * dPhaseO;
+    phaseO += bs * dPhaseO;
 }
 
 template <int bs> void LanczosResampler<bs>::populateNextBlockSizeOS(float *fL, float *fR)


### PR DESCRIPTION
populateNextBlockSize non oversampled version was just off by 2x on block size indexing