### PR TITLE
Fix an interactino between dphase and random lfos

### DIFF
--- a/include/sst/basic-blocks/modulators/SimpleLFO.h
+++ b/include/sst/basic-blocks/modulators/SimpleLFO.h
@@ -178,8 +178,10 @@ template <typename SRProvider, int BLOCK_SIZE, bool clampDeform = false> struct 
         if (dPhase != lastDPhase)
         {
             phase += dPhase - lastDPhase;
-            if (phase > 1)
+            if (phase > 1 && !needsRandomRestart)
                 phase -= 1;
+            if (needsRandomRestart)
+                phase = std::clamp(phase, 0.f, 1.999999f);
         }
         lastDPhase = dPhase;
     }


### PR DESCRIPTION
random lfos use a -start-at-1.0000001 approach to make sure we fully seed the init sequence but this optimization conflicted with the dPhase api which short circuit calls. Fix with a modification of the phase clamp in applyPHaseOffset if a random restart is needed