### PR TITLE
Fix an error with pulse wave ellpitic blep

### DIFF
--- a/include/sst/basic-blocks/dsp/EllipticBlepOscillators.h
+++ b/include/sst/basic-blocks/dsp/EllipticBlepOscillators.h
@@ -357,7 +357,7 @@ struct EBPulse : EBOscillatorBase<EBPulse<SmoothingStrategy>, SmoothingStrategy>
         // mid width turnaround
         if (this->sphase > wval && level > 0)
         {
-            float samplesInPast = (this->phase - 1) / (freq);
+            float samplesInPast = (this->sphase - wval) / (srval * freq);
 
             level = -1;
             // high to low

--- a/libs/elliptic-blep/elliptic-blep.h
+++ b/libs/elliptic-blep/elliptic-blep.h
@@ -4,6 +4,7 @@
 #include <array>
 #include <vector>
 #include <complex>
+#include <cassert>
 
 #ifndef M_PI
 #	define M_PI 3.14159265358979323846
@@ -211,6 +212,7 @@ struct EllipticBlep {
 		
 		auto &bc = poles.blepCoeffs[blepOrder];
 
+		assert(samplesInPast >= 0 && samplesInPast <= 1);
 		Sample tableIndex = samplesInPast*poles.partialStepCount;
 		size_t intIndex = std::floor(tableIndex);
 		Sample fracIndex = tableIndex - std::floor(tableIndex);


### PR DESCRIPTION
where we would have samplesInPast incorrectly calculated at the +ve to -ve turnaroun