### PR TITLE
Take out an errant init step in EBBase

### DIFF
--- a/include/sst/basic-blocks/dsp/EllipticBlepOscillators.h
+++ b/include/sst/basic-blocks/dsp/EllipticBlepOscillators.h
@@ -73,7 +73,6 @@ template <typename Impl, typename SmoothingStrategy = LagSmoothingStrategy> stru
     EBOscillatorBase() : blep(CoeffHolder::getPoleDataForSampleRate(44100))
     {
         SmoothingStrategy::setValueInstant(sratio, 1.0);
-        SmoothingStrategy::setValueInstant(sratio, 0.5);
         reset();
     }
 


### PR DESCRIPTION
which doesn't impact short circuit but does for other systems which never set sync ratio