### PR TITLE
For BELOW_ONE_IS_INVERSE and TWO support negative numbers

### DIFF
--- a/include/sst/basic-blocks/params/ParamMetadata.h
+++ b/include/sst/basic-blocks/params/ParamMetadata.h
@@ -1523,6 +1523,10 @@ inline std::optional<float> ParamMetaData::valueFromString(std::string_view v, s
             else
             {
                 r = std::stof(std::string(v));
+                if (r < 0 && (features & (uint64_t)Features::BELOW_ONE_IS_INVERSE_FRACTION))
+                {
+                    r = 1.0 / -r;
+                }
             }
             assert(svA != 0);
             assert(svB != 0);


### PR DESCRIPTION
For an a 2^ with the BELOW_INE_IS_INVERSE feature set you can type in 1/2 and get 0.5 or 1/4 and get 0.25 or what not. But we also have a convention that -2 and -3 are subharmonics below one, so in this mode a negative number is an inverse for string to value math