### PR TITLE
Add simd_float_extract to extract a lane from an SIMD_M128

### DIFF
--- a/include/sst/basic-blocks/mechanics/simd-ops.h
+++ b/include/sst/basic-blocks/mechanics/simd-ops.h
@@ -95,6 +95,13 @@ inline SIMD_M128 shuffle_all_ps(const SIMD_M128 v)
     }
 }
 
+template <int N>
+    requires(N >= 0 && N < 4)
+inline float simd_float_extract(const SIMD_M128 x)
+{
+    return SIMD_MM(cvtss_f32)(SIMD_MM(shuffle_ps)(x, x, SIMD_MM_SHUFFLE(N, N, N, N)));
+}
+
 } // namespace sst::basic_blocks::mechanics
 
 #endif // SHORTCIRCUIT_SIMD_OPS_H

--- a/tests/simd_tests.cpp
+++ b/tests/simd_tests.cpp
@@ -58,6 +58,17 @@ TEST_CASE("Sums", "[simd]")
     REQUIRE(sst::basic_blocks::mechanics::sum_ps_to_float(val) == Approx(1.0).margin(0.00001));
 }
 
+TEST_CASE("simd_float_extract", "[simd]")
+{
+    float vals alignas(16)[4] = {1.25f, -2.5f, 3.75f, -4.0f};
+    auto v = SIMD_MM(load_ps)(vals);
+
+    REQUIRE(sst::basic_blocks::mechanics::simd_float_extract<0>(v) == Approx(1.25f));
+    REQUIRE(sst::basic_blocks::mechanics::simd_float_extract<1>(v) == Approx(-2.5f));
+    REQUIRE(sst::basic_blocks::mechanics::simd_float_extract<2>(v) == Approx(3.75f));
+    REQUIRE(sst::basic_blocks::mechanics::simd_float_extract<3>(v) == Approx(-4.0f));
+}
+
 TEST_CASE("F32x4", "[simd]")
 {
     float pack1 alignas(16)[4];


### PR DESCRIPTION
Assisted-by: Claude Opus 4.7 <noreply@anthropic.com>