### PR TITLE
Expanded Temposync Support

### DIFF
--- a/include/sst/basic-blocks/modulators/AHDSRShapedSC.h
+++ b/include/sst/basic-blocks/modulators/AHDSRShapedSC.h
@@ -29,6 +29,7 @@
 
 #include "DiscreteStagesEnvelope.h"
 #include "../tables/TwoToTheXProvider.h"
+#include "../tables/TemposyncSupport.h"
 #include <cassert>
 #include <iostream>
 #include <memory>
@@ -120,15 +121,31 @@ struct AHDSRShapedSC : DiscreteStagesEnvelope<BLOCK_SIZE, RangeProvider>
 
     float lastDPhaseX{-1234.56789}, lastDPhase{0}, lastSR{0};
 
+    // set per-block by processCore; consumed by dPhase. temposyncRatio == bpm/120.
+    bool temposyncActive{false};
+    float temposyncRatio{1.f};
+
     inline float dPhase(float x)
     {
         if constexpr (RangeProvider::phaseStrategy == DPhaseStrategies::ENVTIME_2TWOX)
         {
+            assert(!temposyncActive); // TODO - implement this
             return srProvider->envelope_rate_linear_nowrap(x * base_t::etScale + base_t::etMin);
         }
 
         if constexpr (RangeProvider::phaseStrategy == ENVTIME_EXP)
         {
+            if (temposyncActive)
+            {
+                // seconds = beats * 60 / bpm; bpm = 120 * ratio; so dPhase =
+                // BLOCK_SIZE * sampleRateInv / seconds = BLOCK_SIZE * sampleRateInv * 2 * ratio /
+                // beats.
+                auto invBeats = tables::temposync::ZeroOne::inverseBeatsFromFloat(x, true);
+                if (invBeats <= 0.0)
+                    return 1.0; // zero stage -> instant (matches the x==0 convention)
+                return BLOCK_SIZE * srProvider->sampleRateInv * 2.0 * temposyncRatio * invBeats;
+            }
+
             if (x == 0.0)
                 return 1.0;
 
@@ -251,8 +268,11 @@ struct AHDSRShapedSC : DiscreteStagesEnvelope<BLOCK_SIZE, RangeProvider>
     inline void processCore(const float delay, const float a, const float h, const float d,
                             const float s, const float r, const float ashape, const float dshape,
                             const float rshape, const bool gateActive, bool needsCurve,
-                            const float rateMul = 1.0)
+                            const float rateMul = 1.0, bool isTemposync = false,
+                            float temposyncRatio = 1.f)
     {
+        temposyncActive = isTemposync;
+        this->temposyncRatio = temposyncRatio;
         float target = 0;
 
         auto &stage = this->stage;
@@ -467,7 +487,7 @@ struct AHDSRShapedSC : DiscreteStagesEnvelope<BLOCK_SIZE, RangeProvider>
 
     inline void process(const float a, const float h, const float d, const float s, const float r,
                         const float ashape, const float dshape, const float rshape,
-                        const bool gateActive)
+                        const bool gateActive, bool isTemposync = false, float temposyncRatio = 1.f)
     {
         assert(lutsInitialized);
         if (base_t::preBlockCheck())
@@ -475,7 +495,8 @@ struct AHDSRShapedSC : DiscreteStagesEnvelope<BLOCK_SIZE, RangeProvider>
 
         if (this->current == BLOCK_SIZE)
         {
-            processCore(0.f, a, h, d, s, r, ashape, rshape, dshape, gateActive, true);
+            processCore(0.f, a, h, d, s, r, ashape, rshape, dshape, gateActive, true, 1.0,
+                        isTemposync, temposyncRatio);
         }
 
         base_t::step();
@@ -483,17 +504,21 @@ struct AHDSRShapedSC : DiscreteStagesEnvelope<BLOCK_SIZE, RangeProvider>
 
     inline void processBlock(const float a, const float h, const float d, const float s,
                              const float r, const float ashape, const float dshape,
-                             const float rshape, const bool gateActive, bool needsCurve)
+                             const float rshape, const bool gateActive, bool needsCurve,
+                             bool isTemposync = false, float temposyncRatio = 1.f)
     {
-        processCore(0.f, a, h, d, s, r, ashape, dshape, rshape, gateActive, needsCurve);
+        processCore(0.f, a, h, d, s, r, ashape, dshape, rshape, gateActive, needsCurve, 1.0,
+                    isTemposync, temposyncRatio);
     }
 
     inline void processBlockWithDelay(const float delay, const float a, const float h,
                                       const float d, const float s, const float r,
                                       const float ashape, const float dshape, const float rshape,
-                                      const bool gateActive, bool needsCurve)
+                                      const bool gateActive, bool needsCurve,
+                                      bool isTemposync = false, float temposyncRatio = 1.f)
     {
-        processCore(delay, a, h, d, s, r, ashape, dshape, rshape, gateActive, needsCurve);
+        processCore(delay, a, h, d, s, r, ashape, dshape, rshape, gateActive, needsCurve, 1.0,
+                    isTemposync, temposyncRatio);
         // std::cout << "pbwd de=" << delay << " at=" << a << " h=" << h << " d=" << d << " s=" << s
         // << "r= " << r << " ga=" << gateActive << " "; std::cout << " ph=" << phase << " sg=" <<
         // (int)base_t::stage << " re=" << base_t::outBlock0 << std::endl;
@@ -503,10 +528,13 @@ struct AHDSRShapedSC : DiscreteStagesEnvelope<BLOCK_SIZE, RangeProvider>
                                                 const float d, const float s, const float r,
                                                 const float ashape, const float dshape,
                                                 const float rshape, const float rateMul,
-                                                const bool gateActive, bool needsCurve)
+                                                const bool gateActive, bool needsCurve,
+                                                bool isTemposync = false,
+                                                float temposyncRatio = 1.f)
     {
 
-        processCore(delay, a, h, d, s, r, ashape, dshape, rshape, gateActive, needsCurve, rateMul);
+        processCore(delay, a, h, d, s, r, ashape, dshape, rshape, gateActive, needsCurve, rateMul,
+                    isTemposync, temposyncRatio);
         // std::cout << "pbwd de=" << delay << " at=" << a << " h=" << h << " d=" << d << " s=" << s
         // << "r= " << r << " ga=" << gateActive << " "; std::cout << " ph=" << phase << " sg=" <<
         // (int)base_t::stage << " re=" << base_t::outBlock0 << std::endl;

--- a/include/sst/basic-blocks/params/ParamMetadata.h
+++ b/include/sst/basic-blocks/params/ParamMetadata.h
@@ -69,6 +69,8 @@
 #include <fmt/core.h>
 #include <array>
 
+#include "sst/basic-blocks/tables/TemposyncSupport.h"
+
 namespace sst::basic_blocks::params
 {
 struct ParamMetaData
@@ -96,6 +98,8 @@ struct ParamMetaData
     bool canExtend{false}, canDeform{false}, canAbsolute{false}, canTemposync{false},
         canDeactivate{false};
     float temposyncMultiplier{1.f};
+    tables::temposync::Flavor temposyncFlavor{tables::temposync::Flavor::TWO_TO_THE};
+    bool temposyncZeroStage{false}; // ZERO_ONE only: index 0 means a true 0 s
 
     int deformationCount{0};
 
@@ -615,6 +619,18 @@ struct ParamMetaData
         res.temposyncMultiplier = f;
         return res;
     }
+    ParamMetaData withTemposyncFlavor(tables::temposync::Flavor fl)
+    {
+        auto res = *this;
+        res.temposyncFlavor = fl;
+        return res;
+    }
+    ParamMetaData withTemposyncZeroStage(bool b = true)
+    {
+        auto res = *this;
+        res.temposyncZeroStage = b;
+        return res;
+    }
     ParamMetaData extendable(bool b = true)
     {
         auto res = *this;
@@ -1028,6 +1044,16 @@ struct ParamMetaData
             .withMilisecondsBelowOneSecond();
     }
 
+    // as25SecondExpTime plus blanket temposync via the ZERO_ONE note table, with a
+    // true 0 s at the bottom slot (for envelope stages that want a real zero).
+    ParamMetaData as25SecondTemposyncableEnvTime()
+    {
+        return as25SecondExpTime()
+            .temposyncable()
+            .withTemposyncFlavor(tables::temposync::Flavor::ZERO_ONE)
+            .withTemposyncZeroStage();
+    }
+
     ParamMetaData asAudibleFrequency()
     {
         return withType(FLOAT).withRange(-60, 70).withDefault(0).withSemitoneZeroAt440Formatting();
@@ -1101,6 +1127,9 @@ struct ParamMetaData
     std::string temposyncNotation(float f) const;
     std::optional<float> valueFromTemposyncNotation(const std::string &s) const;
     float snapToTemposync(float f) const;
+    // flavor dispatch: TWO_TO_THE vs ZERO_ONE share one Note currency
+    tables::temposync::Note temposyncDecode(float f) const;
+    float temposyncEncode(const tables::temposync::Note &n) const;
 
     std::optional<int> noteNameToNoteNumber(const std::string &s) const;
 
@@ -2057,184 +2086,52 @@ ParamMetaData::modulationNaturalFromString(std::string_view deltaNatural, float 
     return std::nullopt;
 }
 
+inline tables::temposync::Note ParamMetaData::temposyncDecode(float f) const
+{
+    namespace ts = tables::temposync;
+    return temposyncFlavor == ts::Flavor::ZERO_ONE ? ts::ZeroOne::fromFloat(f, temposyncZeroStage)
+                                                   : ts::TwoToThe::fromFloat(f);
+}
+
+inline float ParamMetaData::temposyncEncode(const tables::temposync::Note &n) const
+{
+    namespace ts = tables::temposync;
+    return temposyncFlavor == ts::Flavor::ZERO_ONE ? ts::ZeroOne::toFloat(n, temposyncZeroStage)
+                                                   : ts::TwoToThe::toFloat(n);
+}
+
 inline std::string ParamMetaData::temposyncNotation(float f) const
 {
     assert(type == FLOAT);
-    assert(displayScale == A_TWO_TO_THE_B);
-    assert(svD == 0.f);
-    float a, b = modff(f, &a);
-
-    if (b >= 0)
+    if (temposyncFlavor == tables::temposync::Flavor::TWO_TO_THE)
     {
-        b -= 1.0;
-        a += 1.0;
+        assert(displayScale == A_TWO_TO_THE_B);
+        assert(svD == 0.f);
     }
-
-    float d, q;
-    std::string nn, t;
-    char tmp[1024];
-
-    if (f >= 1)
-    {
-        q = std::pow(2.0f, f - 1);
-        nn = "whole";
-        if (q >= 3)
-        {
-            if (std::fabs(q - floor(q + 0.01)) < 0.01)
-            {
-                snprintf(tmp, 1024, "%d whole notes", (int)floor(q + 0.01));
-            }
-            else
-            {
-                // this is the triplet case
-                snprintf(tmp, 1024, "%d whole triplets", (int)floor(q * 3.0 / 2.0 + 0.02));
-            }
-            std::string res = tmp;
-            return res;
-        }
-        else if (q >= 2)
-        {
-            nn = "double whole";
-            q /= 2;
-        }
-
-        if (q < 1.3)
-        {
-            t = "note";
-        }
-        else if (q < 1.4)
-        {
-            t = "triplet";
-            if (nn == "whole")
-            {
-                nn = "double whole";
-            }
-            else
-            {
-                q = pow(2.0, f - 1);
-                snprintf(tmp, 1024, "%d whole triplets", (int)floor(q * 3.0 / 2.0 + 0.02));
-                std::string res = tmp;
-                return res;
-            }
-        }
-        else
-        {
-            t = "dotted";
-        }
-    }
-    else
-    {
-        d = pow(2.0, -(a - 2));
-        q = pow(2.0, (b + 1));
-
-        if (q < 1.3)
-        {
-            t = "note";
-        }
-        else if (q < 1.4)
-        {
-            t = "triplet";
-            d = d / 2;
-        }
-        else
-        {
-            t = "dotted";
-        }
-        if (d == 1)
-        {
-            nn = "whole";
-        }
-        else
-        {
-            char tmp[1024];
-            snprintf(tmp, 1024, "1/%d", (int)d);
-            nn = tmp;
-        }
-    }
-    std::string res = nn + " " + t;
-
-    return res;
+    return tables::temposync::toString(temposyncDecode(f));
 }
 
 inline std::optional<float> ParamMetaData::valueFromTemposyncNotation(const std::string &s) const
 {
-    // OK so the basic idea is marching down the string we have numbers and slashes
-    // then characters from a constrained set
-    std::string numPart;
-    std::string restPart;
-    bool inNum{true};
-    for (const auto &c : s)
-    {
-        if (inNum && ((c >= '0' && c <= '9') || c == '/' || c == ' '))
-        {
-            numPart += c;
-        }
-        else
-        {
-            inNum = false;
-            if (c != ' ')
-                restPart += std::toupper(c);
-        }
-    }
-    if (numPart.empty())
+    auto n = tables::temposync::fromString(s);
+    if (!n)
         return std::nullopt;
-
-    auto slpos = numPart.find('/');
-    auto num = 0, den = 1;
-    if (slpos == std::string::npos)
-    {
-        num = std::stoi(numPart);
-    }
-    else
-    {
-        num = std::stoi(numPart.substr(0, slpos));
-        den = std::stoi(numPart.substr(slpos + 1));
-    }
-    if (den == 0)
-        return std::nullopt;
-
-    // 1/2 should be 0, 1/4 should be 1
-    auto frac = 2.0 * num / den;
-    auto ufrac = 1.0 / frac;
-    auto pfrac = std::floor(std::log2(ufrac));
-
-    if (restPart == "T")
-        pfrac += 0.51;
-    if (restPart == "D" || restPart == ".")
-    {
-        pfrac -= 0.6;
-    }
-
-    return snapToTemposync(pfrac);
+    return temposyncEncode(*n);
 }
 
 inline float ParamMetaData::snapToTemposync(float f) const
 {
+    namespace ts = tables::temposync;
     assert(canTemposync);
     assert(type == FLOAT);
-    assert(displayScale == A_TWO_TO_THE_B);
-    float a, b = modff(f, &a);
-    if (b < 0)
+    if (temposyncFlavor == ts::Flavor::TWO_TO_THE)
     {
-        b += 1.f;
-        a -= 1.f;
+        assert(displayScale == A_TWO_TO_THE_B);
+        return ts::TwoToThe::snap(f);
     }
-    b = powf(2.0f, b);
-
-    if (b > 1.41f)
-    {
-        b = log2(1.5f);
-    }
-    else if (b > 1.167f)
-    {
-        b = log2(1.3333333333f);
-    }
-    else
-    {
-        b = 0.f;
-    }
-
-    return a + b;
+    // ZERO_ONE is a 0..1 index param by construction
+    assert(minVal == 0.f && maxVal == 1.f);
+    return ts::ZeroOne::snap(f);
 }
 
 inline float ParamMetaData::applyAlternateUnscalingOnFromString(const std::string_view &v,

--- a/include/sst/basic-blocks/tables/TemposyncSupport.h
+++ b/include/sst/basic-blocks/tables/TemposyncSupport.h
@@ -1,0 +1,453 @@
+/*
+ * sst-basic-blocks - an open source library of core audio utilities
+ * built by Surge Synth Team.
+ *
+ * Provides a collection of tools useful on the audio thread for blocks,
+ * modulation, etc... or useful for adapting code to multiple environments.
+ *
+ * Copyright 2023, various authors, as described in the GitHub
+ * transaction log. Parts of this code are derived from similar
+ * functions original in Surge or ShortCircuit.
+ *
+ * sst-basic-blocks is released under the GNU General Public Licence v3
+ * or later (GPL-3.0-or-later). The license is found in the "LICENSE"
+ * file in the root of this repository, or at
+ * https://www.gnu.org/licenses/gpl-3.0.en.html.
+ *
+ * A very small number of explicitly chosen header files can also be
+ * used in an MIT/BSD context. Please see the README.md file in this
+ * repo or the comments in the individual files. Only headers with an
+ * explicit mention that they are dual licensed may be copied and reused
+ * outside the GPL3 terms.
+ *
+ * All source in sst-basic-blocks available at
+ * https://github.com/surge-synthesizer/sst-basic-blocks
+ */
+
+#ifndef INCLUDE_SST_BASIC_BLOCKS_TABLES_TEMPOSYNCSUPPORT_H
+#define INCLUDE_SST_BASIC_BLOCKS_TABLES_TEMPOSYNCSUPPORT_H
+
+#include <array>
+#include <cstdint>
+#include <algorithm>
+#include <string>
+#include <optional>
+#include <cmath>
+#include <cstdio>
+#include <cctype>
+
+namespace sst::basic_blocks::tables::temposync
+{
+
+/*
+ * EXPONENT CONVENTION (used everywhere - there is deliberately no second scale):
+ *
+ *   A Note's `exponent` is base-2 in BEATS with a QUARTER NOTE == 0, i.e.
+ *   beats = 2^exponent.
+ *
+ *     exponent   note        beats
+ *       -5       1/128       1/32
+ *       -1       1/8         1/2
+ *        0       1/4         1     (quarter)
+ *        1       1/2         2
+ *        2       whole       4
+ *        5       8 wholes    32
+ *
+ *   A modifier scales the duration: triplet x2/3, dotted x3/2.
+ *
+ * Two encodings ("flavors") map a parameter's float onto a Note:
+ *   ZERO_ONE   - a 0..1 index into the 33-entry discrete table (struct ZeroOne).
+ *   TWO_TO_THE - the legacy Surge 2^x form. Its math currently still lives in
+ *                ParamMetaData; it will move here as a sibling of ZeroOne in a
+ *                later pass.
+ *
+ * Everything that does not depend on the encoding - the Note struct, secondsFor,
+ * and compact/verbose rendering - is shared below and is flavor-free.
+ */
+enum class Flavor
+{
+    TWO_TO_THE,
+    ZERO_ONE
+};
+
+struct Note
+{
+    enum Modifier : int8_t
+    {
+        Triplet = -1,
+        Straight = 0,
+        Dotted = 1
+    };
+
+    int exponent{0}; // quarter == 0; beats = 2^exponent
+    Modifier modifier{Straight};
+    double beats{1.0}; // duration in beats = 2^exponent * (2/3 | 1 | 3/2)
+
+    constexpr Note() = default;
+    constexpr Note(int e, Modifier m) : exponent(e), modifier(m), beats(beatsFor(e, m)) {}
+
+    static constexpr double beatsFor(int e, Modifier m)
+    {
+        double base = (e >= 0) ? double(1 << e) : 1.0 / double(1 << (-e));
+        double f = (m == Triplet) ? (2.0 / 3.0) : (m == Dotted) ? (3.0 / 2.0) : 1.0;
+        return base * f;
+    }
+
+    // A true zero-duration stage (e.g. an envelope segment of 0 s). beats == 0 is
+    // the sentinel; exponent/modifier are unused for a zero Note.
+    static constexpr Note zeroStage()
+    {
+        Note n;
+        n.beats = 0.0;
+        return n;
+    }
+    constexpr bool isZero() const { return beats == 0.0; }
+};
+
+// Duration in seconds at a given tempo. Flavor-free: a beat = 60/bpm seconds,
+// so seconds = beats * 60 / bpm. (1/4 note @ 60bpm -> 1s.)
+constexpr double secondsFor(const Note &n, double bpm) { return n.beats * 60.0 / bpm; }
+
+/*
+ * Compact ("1/4 T") and verbose ("1/4 triplet") rendering, shared by both
+ * flavors. Sub-whole durations (exponent < 2) read as "1/X"; whole-or-longer as
+ * "NW" / "N whole notes". Dotted in the whole regime resolves to its integer
+ * whole-count (dotted 2W -> "3W", dotted 8W -> "12W") since that reads better; a
+ * dotted single whole (1.5 wholes) has no integer form so it keeps the dotted
+ * form. Triplets never resolve (N*2/3 is never integral here).
+ */
+inline std::string toStringCompact(const Note &n)
+{
+    if (n.isZero())
+        return "0";
+    int e = n.exponent;
+    if (e < 2) // sub-whole: 1/X note
+    {
+        std::string s = "1/" + std::to_string(1 << (2 - e));
+        if (n.modifier == Note::Triplet)
+            s += " T";
+        else if (n.modifier == Note::Dotted)
+            s += " D";
+        return s;
+    }
+    int nWhole = 1 << (e - 2);
+    if (n.modifier == Note::Straight)
+        return std::to_string(nWhole) + "W";
+    if (n.modifier == Note::Triplet)
+        return std::to_string(nWhole) + "W T";
+    if (e >= 3) // dotted of an even whole-count is integral
+        return std::to_string(nWhole * 3 / 2) + "W";
+    return std::to_string(nWhole) + "W D"; // dotted single whole == 1.5 wholes
+}
+
+inline std::string toString(const Note &n)
+{
+    if (n.isZero())
+        return "0 s";
+    int e = n.exponent;
+    if (e < 2)
+    {
+        std::string s = "1/" + std::to_string(1 << (2 - e));
+        if (n.modifier == Note::Triplet)
+            s += " triplet";
+        else if (n.modifier == Note::Dotted)
+            s += " dotted";
+        else
+            s += " note";
+        return s;
+    }
+    int nWhole = 1 << (e - 2);
+    if (n.modifier == Note::Straight)
+        return nWhole == 1 ? "whole note" : std::to_string(nWhole) + " whole notes";
+    if (n.modifier == Note::Triplet)
+        return nWhole == 1 ? "whole triplet" : std::to_string(nWhole) + " whole triplets";
+    if (e >= 3)
+        return std::to_string(nWhole * 3 / 2) + " whole notes";
+    return "dotted whole note";
+}
+
+// Parse a temposync notation string back into a Note - the inverse of toString
+// (and toStringCompact). Handles verbose words ("1/4 triplet", "whole note",
+// "dotted whole note"), compact suffixes ("1/4 T", "2W", "1W D"), and the
+// resolved-dotted whole forms ("3 whole notes" == dotted 2-whole, "12W" == dotted
+// 8-whole). Flavor-neutral; returns nullopt on anything unrecognized.
+inline std::optional<Note> fromString(const std::string &s)
+{
+    std::string numPart, restPart;
+    bool inNum{true};
+    for (const auto &c : s)
+    {
+        if (inNum && ((c >= '0' && c <= '9') || c == '/' || c == ' '))
+            numPart += c;
+        else
+        {
+            inNum = false;
+            if (c != ' ')
+                restPart += std::toupper(c);
+        }
+    }
+
+    // Modifier: verbose words win; otherwise the compact T/D/. suffix (the 'W'
+    // whole-marker is stripped first so "1W T" -> "T").
+    Note::Modifier mod = Note::Straight;
+    if (restPart.find("TRIPLET") != std::string::npos)
+        mod = Note::Triplet;
+    else if (restPart.find("DOTTED") != std::string::npos ||
+             restPart.find('.') != std::string::npos)
+        mod = Note::Dotted;
+    else
+    {
+        std::string core = restPart;
+        core.erase(std::remove(core.begin(), core.end(), 'W'), core.end());
+        if (core == "T")
+            mod = Note::Triplet;
+        else if (core == "D")
+            mod = Note::Dotted;
+    }
+
+    bool hasWhole = restPart.find('W') != std::string::npos;
+
+    bool hasDigit = false;
+    for (char c : numPart)
+        if (c >= '0' && c <= '9')
+        {
+            hasDigit = true;
+            break;
+        }
+
+    int num = 1, den = 1;
+    if (hasDigit)
+    {
+        auto slpos = numPart.find('/');
+        if (slpos == std::string::npos)
+            num = std::stoi(numPart);
+        else
+        {
+            num = std::stoi(numPart.substr(0, slpos));
+            den = std::stoi(numPart.substr(slpos + 1));
+        }
+    }
+    else if (!hasWhole) // no number and not a bare "whole ..." form
+        return std::nullopt;
+    if (hasDigit && num == 0)
+        return Note::zeroStage();
+    if (num <= 0 || den <= 0)
+        return std::nullopt;
+
+    // exponent on the quarter==0 scale from the literal note value
+    int exponent = 1 - (int)std::floor(std::log2((double)den / (2.0 * num)));
+
+    // A whole-count that is not a power of two and has no modifier word is a
+    // resolved-dotted form: "3 whole notes" == dotted 2-whole (count = base*3/2).
+    auto isPow2 = [](int n) { return n > 0 && (n & (n - 1)) == 0; };
+    if (mod == Note::Straight && den == 1 && !isPow2(num))
+    {
+        if (num % 3 == 0 && isPow2(2 * num / 3))
+        {
+            mod = Note::Dotted;
+            exponent = 2 + (int)std::lround(std::log2((double)(2 * num / 3)));
+        }
+        else
+            return std::nullopt;
+    }
+
+    return Note(exponent, mod);
+}
+
+/*
+ * ZERO_ONE table. 11 bases (exponent -5..5: 1/128 note .. 8 whole notes) x 3
+ * modifiers = 33 entries, sorted by duration. Within each octave cell the order
+ * is straight(k) < triplet(k+1) < dotted(k) < straight(k+1), so we emit in that
+ * interleave instead of sorting. Generation is in detail:: free functions: an
+ * in-class static constexpr array cannot be initialized by a member function of
+ * the same (still-incomplete) class.
+ */
+namespace detail
+{
+inline constexpr int zMinExp{-5};
+inline constexpr int zMaxExp{5};
+inline constexpr int zNEntries{(zMaxExp - zMinExp + 1) * 3}; // 33
+
+constexpr std::array<Note, zNEntries> buildEntries()
+{
+    std::array<Note, zNEntries> e{};
+    int i = 0;
+    e[i++] = Note(zMinExp, Note::Triplet);
+    for (int k = zMinExp; k < zMaxExp; ++k)
+    {
+        e[i++] = Note(k, Note::Straight);
+        e[i++] = Note(k + 1, Note::Triplet);
+        e[i++] = Note(k, Note::Dotted);
+    }
+    e[i++] = Note(zMaxExp, Note::Straight);
+    e[i++] = Note(zMaxExp, Note::Dotted);
+    return e;
+}
+
+// Reverse map keyed by baseIndex * 3 + (modifier + 1) for O(1) (base,unit) lookup.
+constexpr std::array<int, zNEntries> buildReverse(const std::array<Note, zNEntries> &e)
+{
+    std::array<int, zNEntries> r{};
+    for (int idx = 0; idx < zNEntries; ++idx)
+        r[(e[idx].exponent - zMinExp) * 3 + (e[idx].modifier + 1)] = idx;
+    return r;
+}
+
+// 1/beats per entry, so DSP rate math is a lookup with no runtime division.
+constexpr std::array<double, zNEntries> buildInverseBeats(const std::array<Note, zNEntries> &e)
+{
+    std::array<double, zNEntries> r{};
+    for (int idx = 0; idx < zNEntries; ++idx)
+        r[idx] = 1.0 / e[idx].beats;
+    return r;
+}
+
+inline constexpr auto zEntries{buildEntries()};
+inline constexpr auto zReverse{buildReverse(zEntries)};
+inline constexpr auto zInverseBeats{buildInverseBeats(zEntries)};
+} // namespace detail
+
+struct ZeroOne
+{
+    using Modifier = Note::Modifier;
+
+    static constexpr int minExp{detail::zMinExp};
+    static constexpr int maxExp{detail::zMaxExp};
+    static constexpr int nBases{maxExp - minExp + 1}; // 11
+    static constexpr int nEntries{detail::zNEntries}; // 33
+    static constexpr float denom{nEntries - 1};       // 32.0 exactly
+
+    static constexpr const std::array<Note, nEntries> &entries{detail::zEntries};
+
+    // ---- 0..1 <-> index ----
+    static constexpr int indexFromZeroOne(float v)
+    {
+        // round by hand (+0.5 then truncate via int cast): std::lround isn't constexpr
+        return (int)(std::clamp(v, 0.f, 1.f) * denom + 0.5f);
+    }
+    static constexpr float zeroOneFromIndex(int idx) { return idx / denom; }
+    static constexpr float snap(float v) { return zeroOneFromIndex(indexFromZeroOne(v)); }
+
+    // ---- value <-> note (provider interface: fromFloat/toFloat) ----
+    // zeroAtBottom: when true the lowest slot (index 0) is a true "0 s" stage
+    // (Note::zeroStage) instead of the smallest note, for envelope segments that
+    // want a real zero. The other 32 slots are unchanged; the smallest note
+    // (1/128 triplet) is simply unavailable in that mode.
+    static constexpr Note fromFloat(float v, bool zeroAtBottom = false)
+    {
+        int idx = indexFromZeroOne(v);
+        if (zeroAtBottom && idx == 0)
+            return Note::zeroStage();
+        return entries[idx];
+    }
+    static constexpr float toFloat(const Note &n, bool zeroAtBottom = false)
+    {
+        if (n.isZero())
+            return zeroOneFromIndex(0); // index 0; valid as zero only when zeroAtBottom
+        (void)zeroAtBottom;
+        int e = std::clamp(n.exponent, minExp, maxExp);
+        return zeroOneFromIndex(detail::zReverse[(e - minExp) * 3 + (n.modifier + 1)]);
+    }
+
+    // Duration in beats for a 0..1 value (snaps internally). Returns 0 at the
+    // zero stage (index 0 when zeroAtBottom), so DSP can do seconds = beats*60/bpm
+    // and get a true 0 s segment.
+    static constexpr double beatsFromFloat(float v, bool zeroAtBottom = false)
+    {
+        return fromFloat(v, zeroAtBottom).beats;
+    }
+
+    // 1/beats for a 0..1 value (snaps internally), as a table lookup. Returns 0
+    // at the zero stage so DSP can treat it as "no rate" (instant).
+    static constexpr double inverseBeatsFromFloat(float v, bool zeroAtBottom = false)
+    {
+        int idx = indexFromZeroOne(v);
+        if (zeroAtBottom && idx == 0)
+            return 0.0;
+        return detail::zInverseBeats[idx];
+    }
+
+    // ---- independent base/unit editor ----
+    static constexpr int baseIndexOf(int idx) { return entries[idx].exponent - minExp; } // 0..10
+    static constexpr Modifier modifierOf(int idx) { return entries[idx].modifier; }
+    static constexpr int indexFor(int baseIndex, Modifier m)
+    {
+        return detail::zReverse[baseIndex * 3 + (m + 1)];
+    }
+};
+
+/*
+ * TWO_TO_THE flavor: the legacy Surge 2^x temposync encoding. Same provider
+ * interface as ZeroOne - fromFloat(float)->Note and toFloat(Note)->float - so
+ * ParamMetaData can render via the shared toString(Note)/fromString and swap
+ * flavors seamlessly. The magic constants (0.51, 0.6, 1.167, 1.41) are
+ * historical Surge values; preserve verbatim. ParamMetaData keeps its own
+ * asserts and temposyncMultiplier handling on its side.
+ */
+struct TwoToThe
+{
+    static inline float snap(float f)
+    {
+        float a, b = modff(f, &a);
+        if (b < 0)
+        {
+            b += 1.f;
+            a -= 1.f;
+        }
+        b = powf(2.0f, b);
+
+        if (b > 1.41f)
+        {
+            b = log2(1.5f);
+        }
+        else if (b > 1.167f)
+        {
+            b = log2(1.3333333333f);
+        }
+        else
+        {
+            b = 0.f;
+        }
+
+        return a + b;
+    }
+
+    // Decode a (snapped) legacy 2^x value into a Note. Derived from the old
+    // temposyncNotation branch logic: with the fractional part normalized to
+    // [0,1), the integer part `a` plus the modifier offset give the note -
+    // straight: a+1, triplet (off ~0.415): a+2, dotted (off ~0.585): a+1.
+    static inline Note fromFloat(float g)
+    {
+        float fa;
+        float b = modff(g, &fa);
+        int a = (int)fa;
+        if (b < 0)
+        {
+            b += 1.f;
+            a -= 1;
+        }
+        if (b > 0.5f)
+            return Note(a + 1, Note::Dotted);
+        if (b > 0.2f)
+            return Note(a + 2, Note::Triplet);
+        return Note(a + 1, Note::Straight);
+    }
+
+    // Encode a Note back to the legacy 2^x value. Matches the old
+    // valueFromTemposyncNotation exactly (rate-like, i.e. WITHOUT the
+    // temposyncMultiplier, which ParamMetaData still applies on its side). The
+    // 0.51 / 0.6 offsets are historical Surge values; preserve verbatim.
+    static inline float toFloat(const Note &n)
+    {
+        float pfrac = (float)(1 - n.exponent);
+        if (n.modifier == Note::Triplet)
+            pfrac += 0.51f;
+        else if (n.modifier == Note::Dotted)
+            pfrac -= 0.6f;
+        return snap(pfrac);
+    }
+};
+
+} // namespace sst::basic_blocks::tables::temposync
+
+#endif // INCLUDE_SST_BASIC_BLOCKS_TABLES_TEMPOSYNCSUPPORT_H

--- a/tests/param_tests.cpp
+++ b/tests/param_tests.cpp
@@ -515,16 +515,16 @@ TEST_CASE("25 Second Exp", "[param]")
 TEST_CASE("Temposync type In")
 {
     std::vector<std::pair<std::string, std::string>> cases = {
-        {"1/32", "1/32 note"},    {"1/16", "1/16 note"},      {"1/8", "1/8 note"},
-        {"1/4", "1/4 note"},      {"1/2", "1/2 note"},        {"1", "whole note"},
-        {"1W", "whole note"},     {"2", "double whole note"}, {"2W", "double whole note"},
+        {"1/32", "1/32 note"},    {"1/16", "1/16 note"},     {"1/8", "1/8 note"},
+        {"1/4", "1/4 note"},      {"1/2", "1/2 note"},       {"1", "whole note"},
+        {"1W", "whole note"},     {"2", "2 whole notes"},    {"2W", "2 whole notes"},
 
-        {"1/4 d", "1/4 dotted"},  {"1/4 .", "1/4 dotted"},    {"1/4.", "1/4 dotted"},
+        {"1/4 d", "1/4 dotted"},  {"1/4 .", "1/4 dotted"},   {"1/4.", "1/4 dotted"},
         {"1/4d", "1/4 dotted"},
 
         {"1/8 t", "1/8 triplet"}, {"1/16t", "1/16 triplet"},
 
-        {"1/4 t", "1/4 triplet"}, {"1/4t", "1/4 triplet"},    {"1/2t", "1/2 triplet"},
+        {"1/4 t", "1/4 triplet"}, {"1/4t", "1/4 triplet"},   {"1/2t", "1/2 triplet"},
         {"1T", "whole triplet"},
     };
     for (const auto &[in, out] : cases)
@@ -539,6 +539,58 @@ TEST_CASE("Temposync type In")
             INFO("Result is " << *s << " " << *v);
             REQUIRE(*s == out);
         }
+    }
+}
+
+TEST_CASE("Temposync ZERO_ONE flavor dispatch")
+{
+    namespace ts = sst::basic_blocks::tables::temposync;
+    using Z = ts::ZeroOne;
+
+    auto p = pmd::ParamMetaData().asFloat().withRange(0.f, 1.f).temposyncable().withTemposyncFlavor(
+        ts::Flavor::ZERO_ONE);
+    auto fs = pmd::ParamMetaData::FeatureState().withTemposync(true);
+
+    SECTION("snap + notation dispatch to the ZeroOne/Note path for every grid value")
+    {
+        for (int i = 0; i < Z::nEntries; ++i)
+        {
+            float v = Z::zeroOneFromIndex(i);
+            REQUIRE(p.snapToTemposync(v) == Approx(Z::snap(v)));
+            REQUIRE(p.temposyncNotation(v) == ts::toString(Z::fromFloat(v)));
+        }
+    }
+
+    SECTION("valueToString renders the ZeroOne note (not the 2^x convention)")
+    {
+        float q = Z::zeroOneFromIndex(Z::indexFor(0 - Z::minExp, ts::Note::Straight));
+        auto s = p.valueToString(q, fs);
+        REQUIRE(s.has_value());
+        REQUIRE(*s == "1/4 note");
+    }
+
+    SECTION("typed compact note decodes through ZeroOne")
+    {
+        auto v = p.valueFromTemposyncNotation("1/8 T");
+        REQUIRE(v.has_value());
+        auto n = Z::fromFloat(*v);
+        REQUIRE(n.exponent == -1); // 1/8 == exponent -1 on the quarter==0 scale
+        REQUIRE(n.modifier == ts::Note::Triplet);
+    }
+
+    SECTION("zero-stage flavor renders index 0 as a true zero")
+    {
+        auto pz = pmd::ParamMetaData()
+                      .asFloat()
+                      .withRange(0.f, 1.f)
+                      .temposyncable()
+                      .withTemposyncFlavor(ts::Flavor::ZERO_ONE)
+                      .withTemposyncZeroStage();
+        auto fz = pmd::ParamMetaData::FeatureState().withTemposync(true);
+        REQUIRE(*pz.valueToString(0.f, fz) == "0 s");
+        REQUIRE(*pz.valueToString(Z::zeroOneFromIndex(1), fz) == ts::toString(Z::entries[1]));
+        // without the zero stage, index 0 is the smallest note
+        REQUIRE(*p.valueToString(0.f, fs) == ts::toString(Z::entries[0]));
     }
 }
 

--- a/tests/table_tests.cpp
+++ b/tests/table_tests.cpp
@@ -31,6 +31,7 @@
 #include "sst/basic-blocks/tables/EqualTuningProvider.h"
 #include "sst/basic-blocks/tables/TwoToTheXProvider.h"
 #include "sst/basic-blocks/tables/ExpTimeProvider.h"
+#include "sst/basic-blocks/tables/TemposyncSupport.h"
 
 namespace tabl = sst::basic_blocks::tables;
 
@@ -112,5 +113,187 @@ TEST_CASE("ExpTimeProvider TwentyFiveSecondExpTable", "[tables]")
         auto t1 = expTime.timeInSecondsFromParam(1.0);
         REQUIRE(t1 > 20.0);
         REQUIRE(t1 < 30.0);
+    }
+}
+
+TEST_CASE("Temposync ZeroOne", "[tables]")
+{
+    namespace ts = sst::basic_blocks::tables::temposync;
+    using Z = ts::ZeroOne;
+    using N = ts::Note;
+
+    SECTION("Shape and exact denominator")
+    {
+        REQUIRE(Z::nBases == 11);
+        REQUIRE(Z::nEntries == 33);
+        REQUIRE(Z::denom == 32.f); // 33 - 1, a power of two -> exact index/denom
+    }
+
+    SECTION("Entries are strictly ordered by duration")
+    {
+        for (int i = 1; i < Z::nEntries; ++i)
+        {
+            INFO("entry " << i << " vs " << (i - 1));
+            REQUIRE(Z::entries[i].beats > Z::entries[i - 1].beats);
+        }
+    }
+
+    SECTION("Note stores a consistent beats value")
+    {
+        for (int i = 0; i < Z::nEntries; ++i)
+        {
+            const auto &n = Z::entries[i];
+            REQUIRE(n.beats == Approx(N::beatsFor(n.exponent, n.modifier)));
+        }
+    }
+
+    SECTION("index -> 0..1 -> index is exact for every entry")
+    {
+        for (int i = 0; i < Z::nEntries; ++i)
+            REQUIRE(Z::indexFromZeroOne(Z::zeroOneFromIndex(i)) == i);
+    }
+
+    SECTION("Reverse map inverts baseIndexOf/modifierOf")
+    {
+        for (int i = 0; i < Z::nEntries; ++i)
+            REQUIRE(Z::indexFor(Z::baseIndexOf(i), Z::modifierOf(i)) == i);
+        for (int b = 0; b < Z::nBases; ++b)
+        {
+            for (auto mod : {N::Triplet, N::Straight, N::Dotted})
+            {
+                int idx = Z::indexFor(b, mod);
+                REQUIRE(Z::baseIndexOf(idx) == b);
+                REQUIRE(Z::modifierOf(idx) == mod);
+            }
+        }
+    }
+
+    SECTION("Quarter convention: exponent 0 == quarter == 1 beat")
+    {
+        int q = Z::indexFor(0 - Z::minExp, N::Straight); // exponent 0
+        REQUIRE(Z::entries[q].exponent == 0);
+        REQUIRE(Z::entries[q].beats == Approx(1.0));
+        REQUIRE(ts::toStringCompact(Z::entries[q]) == "1/4");
+        REQUIRE(ts::secondsFor(Z::entries[q], 60.0) == Approx(1.0));
+        REQUIRE(ts::secondsFor(Z::entries[q], 120.0) == Approx(0.5));
+    }
+
+    SECTION("Range endpoints and modifier math")
+    {
+        REQUIRE(ts::toStringCompact(Z::entries[0]) == "1/128 T");
+        REQUIRE(Z::entries[0].beats == Approx(1.0 / 48.0)); // 1/32 beat * 2/3
+        REQUIRE(ts::toStringCompact(Z::entries[Z::nEntries - 1]) == "12W");
+        REQUIRE(Z::entries[Z::nEntries - 1].beats == Approx(48.0)); // 32 beats * 3/2
+
+        int eighth = Z::indexFor(-1 - Z::minExp, N::Straight); // exponent -1 == 1/8 note
+        int eighthD = Z::indexFor(-1 - Z::minExp, N::Dotted);
+        int eighthT = Z::indexFor(-1 - Z::minExp, N::Triplet);
+        REQUIRE(ts::toStringCompact(Z::entries[eighth]) == "1/8");
+        REQUIRE(Z::entries[eighthD].beats == Approx(Z::entries[eighth].beats * 1.5));
+        REQUIRE(Z::entries[eighthT].beats == Approx(Z::entries[eighth].beats * 2.0 / 3.0));
+    }
+
+    SECTION("noteFromValue / valueFromNote round-trip on every entry")
+    {
+        for (int i = 0; i < Z::nEntries; ++i)
+        {
+            auto v = Z::zeroOneFromIndex(i);
+            REQUIRE(Z::toFloat(Z::fromFloat(v)) == Approx(v));
+        }
+    }
+
+    SECTION("snap lands on a representable 0..1 value")
+    {
+        for (float v = 0.f; v <= 1.f; v += 0.013f)
+        {
+            float sn = Z::snap(v);
+            REQUIRE(Z::zeroOneFromIndex(Z::indexFromZeroOne(sn)) == sn);
+        }
+    }
+
+    SECTION("Full notation table matches the agreed spec")
+    {
+        static const char *expectedCompact[Z::nEntries] = {
+            "1/128 T", "1/128", "1/64 T", "1/128 D", "1/64", "1/32 T", "1/64 D", "1/32", "1/16 T",
+            "1/32 D",  "1/16",  "1/8 T",  "1/16 D",  "1/8",  "1/4 T",  "1/8 D",  "1/4",  "1/2 T",
+            "1/4 D",   "1/2",   "1W T",   "1/2 D",   "1W",   "2W T",   "1W D",   "2W",   "4W T",
+            "3W",      "4W",    "8W T",   "6W",      "8W",   "12W"};
+        static const char *expectedVerbose[Z::nEntries] = {
+            "1/128 triplet",     "1/128 note",       "1/64 triplet",     "1/128 dotted",
+            "1/64 note",         "1/32 triplet",     "1/64 dotted",      "1/32 note",
+            "1/16 triplet",      "1/32 dotted",      "1/16 note",        "1/8 triplet",
+            "1/16 dotted",       "1/8 note",         "1/4 triplet",      "1/8 dotted",
+            "1/4 note",          "1/2 triplet",      "1/4 dotted",       "1/2 note",
+            "whole triplet",     "1/2 dotted",       "whole note",       "2 whole triplets",
+            "dotted whole note", "2 whole notes",    "4 whole triplets", "3 whole notes",
+            "4 whole notes",     "8 whole triplets", "6 whole notes",    "8 whole notes",
+            "12 whole notes"};
+        for (int i = 0; i < Z::nEntries; ++i)
+        {
+            INFO("idx " << i);
+            REQUIRE(ts::toStringCompact(Z::entries[i]) == expectedCompact[i]);
+            REQUIRE(ts::toString(Z::entries[i]) == expectedVerbose[i]);
+        }
+    }
+
+    SECTION("fromString(toString(n)) round-trips every entry (verbose and compact)")
+    {
+        for (int i = 0; i < Z::nEntries; ++i)
+        {
+            auto n = Z::entries[i];
+            INFO("verbose entry " << i << " '" << ts::toString(n) << "'");
+            auto v = ts::fromString(ts::toString(n));
+            REQUIRE(v.has_value());
+            REQUIRE(v->exponent == n.exponent);
+            REQUIRE(v->modifier == n.modifier);
+
+            INFO("compact entry " << i << " '" << ts::toStringCompact(n) << "'");
+            auto c = ts::fromString(ts::toStringCompact(n));
+            REQUIRE(c.has_value());
+            REQUIRE(c->exponent == n.exponent);
+            REQUIRE(c->modifier == n.modifier);
+        }
+    }
+
+    SECTION("Zero-stage mode puts a true 0 at the bottom index")
+    {
+        auto z = Z::fromFloat(0.f, true);
+        REQUIRE(z.isZero());
+        REQUIRE(ts::secondsFor(z, 120.0) == 0.0);
+        REQUIRE(ts::toString(z) == "0 s");
+        REQUIRE(ts::toStringCompact(z) == "0");
+        REQUIRE(Z::toFloat(z, true) == Approx(Z::zeroOneFromIndex(0)));
+
+        // the other 32 slots are unchanged from non-zero mode
+        for (int i = 1; i < Z::nEntries; ++i)
+        {
+            auto n = Z::fromFloat(Z::zeroOneFromIndex(i), true);
+            REQUIRE_FALSE(n.isZero());
+            REQUIRE(n.exponent == Z::entries[i].exponent);
+            REQUIRE(n.modifier == Z::entries[i].modifier);
+        }
+
+        // default mode still maps index 0 to the smallest note
+        REQUIRE_FALSE(Z::fromFloat(0.f).isZero());
+        REQUIRE(Z::fromFloat(0.f).exponent == Z::entries[0].exponent);
+
+        // "0" / "0 s" parse to the zero stage
+        REQUIRE(ts::fromString("0").has_value());
+        REQUIRE(ts::fromString("0")->isZero());
+        REQUIRE(ts::fromString("0 s")->isZero());
+
+        // beatsFromFloat: zero at the bottom, real beats elsewhere
+        REQUIRE(Z::beatsFromFloat(0.f, true) == 0.0);
+        REQUIRE(Z::beatsFromFloat(Z::zeroOneFromIndex(1), true) == Z::entries[1].beats);
+        REQUIRE(Z::beatsFromFloat(0.f, false) == Z::entries[0].beats); // non-zero mode
+
+        // inverseBeatsFromFloat: 1/beats lookup, 0 at the zero stage
+        REQUIRE(Z::inverseBeatsFromFloat(0.f, true) == 0.0);
+        for (int i = 1; i < Z::nEntries; ++i)
+        {
+            auto v = Z::zeroOneFromIndex(i);
+            REQUIRE(Z::inverseBeatsFromFloat(v, true) == Approx(1.0 / Z::entries[i].beats));
+            REQUIRE(Z::inverseBeatsFromFloat(v) == Approx(1.0 / Z::entries[i].beats));
+        }
     }
 }


### PR DESCRIPTION
1. Add a tables/TempoSyncSupport.h header to encapsulate Temposync work
2. Port the surge 2^x temposync support there with core functions to snap to/from float and convert to/from string
3. Introduce a 0...1 temposync mapping for the exp ranges used in short circuit and six sines
4. Backfill ParamMetadata to call this code for display in either case with the appropriate flavor
5. Update AHDSRShapedSC for the exp range to allow temposync
6. Add tests to show both adherance with prior behviour and check quite a few more cases

Still to do is AHDSRShapedSC in the 2^x range (currently unsued) and
 the DAR exp envelope.

Assisted-By: Claude Opus 4.8