### PR TITLE
Add a method to interpolate temposync for modulation

### DIFF
--- a/include/sst/basic-blocks/modulators/AHDSRShapedSC.h
+++ b/include/sst/basic-blocks/modulators/AHDSRShapedSC.h
@@ -139,11 +139,12 @@ struct AHDSRShapedSC : DiscreteStagesEnvelope<BLOCK_SIZE, RangeProvider>
             {
                 // seconds = beats * 60 / bpm; bpm = 120 * ratio; so dPhase =
                 // BLOCK_SIZE * sampleRateInv / seconds = BLOCK_SIZE * sampleRateInv * 2 * ratio /
-                // beats.
-                auto invBeats = tables::temposync::ZeroOne::inverseBeatsFromFloat(x, true);
-                if (invBeats <= 0.0)
+                // beats. Use the interpolated (not snapped) beats so a modulated time glides
+                // between notes; an unmodulated, UI-snapped value still lands exactly on a note.
+                auto beats = tables::temposync::ZeroOne::interpolatedBeatsFromFloat(x, true);
+                if (beats <= 0.0)
                     return 1.0; // zero stage -> instant (matches the x==0 convention)
-                return BLOCK_SIZE * srProvider->sampleRateInv * 2.0 * temposyncRatio * invBeats;
+                return BLOCK_SIZE * srProvider->sampleRateInv * 2.0 * temposyncRatio / beats;
             }
 
             if (x == 0.0)

--- a/include/sst/basic-blocks/tables/TemposyncSupport.h
+++ b/include/sst/basic-blocks/tables/TemposyncSupport.h
@@ -367,6 +367,24 @@ struct ZeroOne
         return detail::zInverseBeats[idx];
     }
 
+    // Continuous duration in beats: piecewise-linear in beats between adjacent
+    // grid notes, so a modulated value glides instead of snapping cell-to-cell.
+    // Exact at grid points (index/denom), where it equals beatsFromFloat, so an
+    // unmodulated (UI-snapped) value reproduces the snapped duration with no
+    // special case. Interpolating beats (rather than inverseBeats) keeps the
+    // zero stage well behaved: the index 0->1 cell ramps up from 0.
+    static constexpr double interpolatedBeatsFromFloat(float v, bool zeroAtBottom = false)
+    {
+        float xp = std::clamp(v, 0.f, 1.f) * denom;
+        int xpi = (int)xp;
+        if (xpi >= nEntries - 1)
+            return entries[nEntries - 1].beats;
+        float xpf = xp - xpi;
+        double b0 = (zeroAtBottom && xpi == 0) ? 0.0 : entries[xpi].beats;
+        double b1 = entries[xpi + 1].beats;
+        return (1.0 - xpf) * b0 + xpf * b1;
+    }
+
     // ---- independent base/unit editor ----
     static constexpr int baseIndexOf(int idx) { return entries[idx].exponent - minExp; } // 0..10
     static constexpr Modifier modifierOf(int idx) { return entries[idx].modifier; }

--- a/tests/table_tests.cpp
+++ b/tests/table_tests.cpp
@@ -296,4 +296,54 @@ TEST_CASE("Temposync ZeroOne", "[tables]")
             REQUIRE(Z::inverseBeatsFromFloat(v) == Approx(1.0 / Z::entries[i].beats));
         }
     }
+
+    SECTION("ZeroOne interpolated beats")
+    {
+        using Z = ts::ZeroOne;
+
+        // Exact at every grid knot: matches the snapped beatsFromFloat there, so
+        // an unmodulated (UI-snapped) value glides nowhere.
+        for (int i = 0; i < Z::nEntries; ++i)
+        {
+            auto v = Z::zeroOneFromIndex(i);
+            REQUIRE(Z::interpolatedBeatsFromFloat(v, true) == Z::beatsFromFloat(v, true));
+            REQUIRE(Z::interpolatedBeatsFromFloat(v, false) == Z::beatsFromFloat(v, false));
+        }
+
+        // Boundaries. At 0 with zeroAtBottom it is the zero stage (0 beats); at 0
+        // without it is the smallest note; at 1 it is the largest note. All three
+        // are clamped knots, so interpolation == the table value exactly.
+        REQUIRE(Z::interpolatedBeatsFromFloat(0.f, true) == 0.0);
+        REQUIRE(Z::interpolatedBeatsFromFloat(0.f, false) == Z::entries[0].beats);
+        REQUIRE(Z::interpolatedBeatsFromFloat(1.f, true) == Z::entries[Z::nEntries - 1].beats);
+        REQUIRE(Z::interpolatedBeatsFromFloat(1.f, false) == Z::entries[Z::nEntries - 1].beats);
+        // Out of range clamps to the endpoints rather than extrapolating.
+        REQUIRE(Z::interpolatedBeatsFromFloat(-0.5f, false) == Z::entries[0].beats);
+        REQUIRE(Z::interpolatedBeatsFromFloat(1.5f, false) == Z::entries[Z::nEntries - 1].beats);
+
+        // Midpoint of a cell is the arithmetic mean of its endpoints (linear in
+        // beats), and the lowest cell ramps up from 0 under zeroAtBottom.
+        {
+            auto v0 = Z::zeroOneFromIndex(0);
+            auto v1 = Z::zeroOneFromIndex(1);
+            auto mid = 0.5f * (v0 + v1);
+            REQUIRE(Z::interpolatedBeatsFromFloat(mid, true) ==
+                    Approx(0.5 * Z::entries[1].beats)); // (0 + b1)/2
+            REQUIRE(Z::interpolatedBeatsFromFloat(mid, false) ==
+                    Approx(0.5 * (Z::entries[0].beats + Z::entries[1].beats)));
+        }
+
+        // Strictly monotonic increasing across a fine sweep: modulation always
+        // moves continuously, never flat or backward.
+        double prev = -1.0;
+        for (int k = 0; k <= 2000; ++k)
+        {
+            auto v = k / 2000.f;
+            auto b = Z::interpolatedBeatsFromFloat(v, true);
+            REQUIRE(b >= prev);
+            if (v > 0.f && v < 1.f)
+                REQUIRE(b > prev); // strictly increasing in the interior
+            prev = b;
+        }
+    }
 }


### PR DESCRIPTION
Since last commit forced snap even in mouldated input. Basically make the snap the responsibility of the envelope client like the 2^x case