### PR TITLE
Fix two problems makign ModMatrix non-rt safe

### DIFF
--- a/.github/workflows/build-tests.yml
+++ b/.github/workflows/build-tests.yml
@@ -32,24 +32,24 @@ jobs:
             name: mac-arm-nonative
             cmakeArgs: -DCMAKE_OSX_ARCHITECTURES=arm64 -DSST_BASIC_BLOCKS_SIMD_OMIT_NATIVE_ALIASES=TRUE
 
-          - os: windows-latest
+          - os: windows-2022
             name: win-x86
             runTest: true
             testExe: build/Release/sst-basic-blocks-test.exe
 
-          - os: windows-latest
+          - os: windows-2022
             name: win-clang-cl
             cmakeArgs: -G"Visual Studio 17 2022" -A x64 -T ClangCL
 
-          - os: windows-latest
+          - os: windows-2022
             name: win-arm64
             cmakeArgs: -G"Visual Studio 17 2022" -A arm64 -DCMAKE_SYSTEM_VERSION=10
 
-          - os: windows-latest
+          - os: windows-2022
             name: win-arm64ec
             cmakeArgs: -G"Visual Studio 17 2022" -A arm64ec -DCMAKE_SYSTEM_VERSION=10
 
-          - os: windows-latest
+          - os: windows-2022
             name: win-arm64-non-native
             cmakeArgs: -G"Visual Studio 17 2022" -A arm64 -DCMAKE_SYSTEM_VERSION=10 -DSST_BASIC_BLOCKS_SIMD_OMIT_NATIVE_ALIASES=TRUE
 

--- a/include/sst/basic-blocks/mod-matrix/ModMatrix.h
+++ b/include/sst/basic-blocks/mod-matrix/ModMatrix.h
@@ -38,6 +38,7 @@
 #include <cmath>
 
 #include <iostream>
+#include "sst/cpputils/small_hash_map.h"
 #include "ModMatrixDetails.h"
 #include "../dsp/Lag.h"
 
@@ -102,31 +103,26 @@ struct ModMatrix : details::CheckModMatrixConstraints<ModMatrixTraits>
 {
     using TR = ModMatrixTraits;
 
-    std::unordered_map<typename TR::TargetIdentifier, float &> baseValues;
-    std::unordered_map<typename TR::TargetIdentifier, float &> unmodulatedValues;
+    std::unordered_map<typename TR::TargetIdentifier, float *> baseValues;
+    std::unordered_map<typename TR::TargetIdentifier, float *> unmodulatedValues;
     void bindTargetBaseValue(const typename TR::TargetIdentifier &t, float &f)
     {
-        baseValues.erase(t);
-        baseValues.insert_or_assign(t, f);
-        unmodulatedValues.erase(t);
-        unmodulatedValues.insert_or_assign(t, f);
+        baseValues.insert_or_assign(t, &f);
+        unmodulatedValues.insert_or_assign(t, &f);
     }
 
     void bindTargetBaseValueWithDistinctUnmodulatedValue(const typename TR::TargetIdentifier &t,
                                                          float &base, float &unmod)
     {
-        baseValues.erase(t);
-        baseValues.insert_or_assign(t, base);
-        unmodulatedValues.erase(t);
-        unmodulatedValues.insert_or_assign(t, unmod);
+        baseValues.insert_or_assign(t, &base);
+        unmodulatedValues.insert_or_assign(t, &unmod);
     }
 
-    std::unordered_map<typename TR::SourceIdentifier, float &> sourceValues;
+    std::unordered_map<typename TR::SourceIdentifier, float *> sourceValues;
     std::unordered_map<typename TR::SourceIdentifier, float> constantPlaceholders;
     void bindSourceValue(const typename TR::SourceIdentifier &s, float &f)
     {
-        sourceValues.erase(s);
-        sourceValues.insert_or_assign(s, f);
+        sourceValues.insert_or_assign(s, &f);
     }
 
     void bindSourceConstantValue(const typename TR::SourceIdentifier &c, float value)
@@ -273,9 +269,12 @@ template <typename ModMatrixTraits> struct FixedMatrix : ModMatrix<ModMatrixTrai
     std::array<RoutingValuePointers, TR::FixedMatrixSize> routingValuePointers{};
     std::array<size_t, TR::FixedMatrixSize> routingValuePointersProcessOrder{};
 
-    std::unordered_map<typename TR::TargetIdentifier, bool> isOutputMapped;
-    std::unordered_map<typename TR::TargetIdentifier, size_t> targetToOutputIndex;
-    std::unordered_map<typename TR::SourceIdentifier, bool> isSourceUsed;
+    sst::cpputils::SmallHashMap<typename TR::TargetIdentifier, bool, TR::FixedMatrixSize>
+        isOutputMapped;
+    sst::cpputils::SmallHashMap<typename TR::TargetIdentifier, size_t, TR::FixedMatrixSize>
+        targetToOutputIndex;
+    sst::cpputils::SmallHashMap<typename TR::SourceIdentifier, bool, 2 * TR::FixedMatrixSize>
+        isSourceUsed;
 
     void updateRoutingState(const RoutingTable &rt)
     {
@@ -295,7 +294,7 @@ template <typename ModMatrixTraits> struct FixedMatrix : ModMatrix<ModMatrixTrai
 
             if (targetToOutputIndex.find(*r.target) == targetToOutputIndex.end())
             {
-                targetToOutputIndex.insert_or_assign(*r.target, outIdx);
+                targetToOutputIndex[*r.target] = outIdx;
                 outIdx++;
             }
         }
@@ -306,7 +305,7 @@ template <typename ModMatrixTraits> struct FixedMatrix : ModMatrix<ModMatrixTrai
         updateRoutingState(rt);
 
         int idx{0};
-        std::unordered_set<typename TR::TargetIdentifier> depthMaps;
+        sst::cpputils::SmallHashSet<typename TR::TargetIdentifier, TR::FixedMatrixSize> depthMaps;
         for (auto &r : rt.routes)
         {
             if (!r.source.has_value() && !r.target.has_value())
@@ -324,7 +323,7 @@ template <typename ModMatrixTraits> struct FixedMatrix : ModMatrix<ModMatrixTrai
                 continue;
             }
 
-            rv.source = &this->sourceValues.at(*r.source);
+            rv.source = this->sourceValues.at(*r.source);
             if (ModMatrix<TR>::supportsLag(*r.source) && r.sourceLagMS > 0)
             {
                 if (r.sourceLagExp)
@@ -348,7 +347,7 @@ template <typename ModMatrixTraits> struct FixedMatrix : ModMatrix<ModMatrixTrai
             }
             if (r.sourceVia.has_value())
             {
-                rv.sourceVia = &this->sourceValues.at(*(r.sourceVia));
+                rv.sourceVia = this->sourceValues.at(*(r.sourceVia));
                 if (ModMatrix<TR>::supportsLag(*r.sourceVia) && r.sourceViaLagMS > 0)
                 {
                     if (r.sourceViaLagExp)
@@ -404,7 +403,7 @@ template <typename ModMatrixTraits> struct FixedMatrix : ModMatrix<ModMatrixTrai
                 auto depthIndex = TR::getTargetModMatrixElement(m);
                 assert(depthIndex < routingValuePointers.size());
                 routingValuePointers[depthIndex].depth = &matrixOutputs[targetToOutputIndex.at(m)];
-                this->baseValues.insert_or_assign(m, rt.routes[depthIndex].depth);
+                this->baseValues.insert_or_assign(m, &rt.routes[depthIndex].depth);
             }
         }
 
@@ -434,7 +433,7 @@ template <typename ModMatrixTraits> struct FixedMatrix : ModMatrix<ModMatrixTrai
         {
             if constexpr (ModMatrixTraits::ProvidesNonZeroTargetBases)
             {
-                matrixOutputs[outIdx] = this->baseValues.at(tgt);
+                matrixOutputs[outIdx] = *this->baseValues.at(tgt);
             }
             else
             {
@@ -554,7 +553,7 @@ template <typename ModMatrixTraits> struct FixedMatrix : ModMatrix<ModMatrixTrai
         auto f = isOutputMapped.find(s);
         if (f == isOutputMapped.end() || !f->second)
         {
-            return &this->unmodulatedValues.at(s);
+            return this->unmodulatedValues.at(s);
         }
         else
         {


### PR DESCRIPTION
Two things made ModMatrix non-rt safe

1. The depth map and so on - which were size target list - used maps but those maps were std::unordered_map which would allocate. Replace with a small hashset
2. The big map of target to value is also an unordered_map but was an unordered map of float &. That meant there was no pre-allocation available. Change it to a map of float*. This means that the matrix will still allocate if constructed afresh, but with float*, allows a strategy of warming up and retaining the data structure in an engine while keeping the same data structure. ShortCircuit now follows that strategy.

Assisted-By: Claude Opus 4.8