### PR TITLE
Invert unordered map; Handle epsilon range errors

### DIFF
--- a/include/sst/basic-blocks/params/ParamMetadata.h
+++ b/include/sst/basic-blocks/params/ParamMetadata.h
@@ -1413,12 +1413,36 @@ inline std::optional<int> ParamMetaData::noteNameToNoteNumber(const std::string 
 inline std::optional<float> ParamMetaData::valueFromString(std::string_view v, std::string &errMsg,
                                                            const FeatureState &fs) const
 {
+    // The UNORDERED_MAP forward direction is discreteValues[round(val)] -> label; to invert we
+    // scan the map for a matching label. Exact match first (strict inversion) then a
+    // case-insensitive fallback so typeins like "2 baRs" resolve to key "2 Bars".
+    auto fromUnorderedMap = [this, v]() -> std::optional<float> {
+        if (displayScale != UNORDERED_MAP)
+            return std::nullopt;
+        for (const auto &[k, label] : discreteValues)
+            if (label == v)
+                return (float)k;
+        auto lc = [](std::string_view s) {
+            std::string r(s);
+            std::transform(r.begin(), r.end(), r.begin(),
+                           [](unsigned char c) { return (char)std::tolower(c); });
+            return r;
+        };
+        auto target = lc(v);
+        for (const auto &[k, label] : discreteValues)
+            if (lc(label) == target)
+                return (float)k;
+        return std::nullopt;
+    };
+
     if (type == BOOL)
     {
         if (v == "On" || v == "on" || v == "1" || v == "true" || v == "True")
             return 1.f;
         if (v == "Off" || v == "off" || v == "0" || v == "false" || v == "False")
             return 0.f;
+        if (auto r = fromUnorderedMap())
+            return r;
     }
     if (type == INT)
     {
@@ -1445,6 +1469,9 @@ inline std::optional<float> ParamMetaData::valueFromString(std::string_view v, s
             if (res >= minVal && res <= maxVal)
                 return res;
         }
+        if (auto r = fromUnorderedMap())
+            return *r;
+
         return std::nullopt;
     }
 
@@ -1598,6 +1625,13 @@ inline std::optional<float> ParamMetaData::valueFromString(std::string_view v, s
              * (log2((v-svD)/svA) - svC)/svB = r
              */
             r = (log2((r - svD) / svA) - svC) / svB;
+
+            // This has a float rounding issue at the extrema
+            if (std::fabs(r - maxVal) < 1e-6 && r > maxVal)
+                return maxVal;
+            if (std::fabs(r - minVal) < 1e-6 && r < minVal)
+                return minVal;
+
             if (r < minVal || r > maxVal)
             {
                 errMsg = rangeMsg();

--- a/tests/param_tests.cpp
+++ b/tests/param_tests.cpp
@@ -911,6 +911,26 @@ TEST_CASE("Unordered Map Display", "[param]")
         REQUIRE(*(p.valueToString(2)) == "Fast");
         REQUIRE(!p.valueToString(3).has_value()); // out of map → nullopt
     }
+
+    SECTION("Inverts from string, case-insensitively")
+    {
+        auto p = pmd::ParamMetaData().asInt().withRange(-1, 3).withUnorderedMapFormatting(
+            {{-1, "Song Pos"}, {0, "Each Bar"}, {1, "2 Bars"}, {2, "4 Bars"}, {3, "On Start"}});
+
+        std::string em;
+        // strict inversion of the exact labels
+        REQUIRE(p.valueFromString("Song Pos", em).value_or(1000) == -1);
+        REQUIRE(p.valueFromString("2 Bars", em).value_or(1000) == 1);
+        REQUIRE(p.valueFromString("On Start", em).value_or(1000) == 3);
+
+        // case-insensitive typeins resolve to the same key
+        REQUIRE(p.valueFromString("2 baRs", em).value_or(1000) == 1);
+        REQUIRE(p.valueFromString("song pos", em).value_or(1000) == -1);
+        REQUIRE(p.valueFromString("EACH BAR", em).value_or(1000) == 0);
+
+        // unknown labels still fail
+        REQUIRE(!p.valueFromString("8 Bars", em).has_value());
+    }
 }
 
 TEST_CASE("Value To Alternate String", "[param]")


### PR DESCRIPTION
- A parameter with unordered map formatting consults it in value from string.
- If you are in 2^x mode and the log comes out epsilon outside of range, return range max/min not an error

Assisted-By: Claude Opus 4.8