### PR TITLE
Add a simple LERP interpolator

### DIFF
--- a/include/sst/basic-blocks/dsp/BlockInterpolators.h
+++ b/include/sst/basic-blocks/dsp/BlockInterpolators.h
@@ -321,6 +321,47 @@ template <int maxBlockSize, bool first_run_checks = true> struct alignas(16) lip
         current = target;
     }
 };
+
+/*
+ * SimpleLerp: a stateless, block-size-templated linear ramp. Unlike lipol / lipol_sse it holds no
+ * per-instance line — you pass the two endpoints on each call and the fixed-N loop is left for the
+ * compiler to unroll and vectorize (each sample is an independent `start + dv*(s+1)`, so there is
+ * no loop-carried += to block the vectorizer). `end` is the value the final sample lands on
+ * (end-of-block convention): feed the previous block's value as `start` and this block's as `end`
+ * to ramp a per-block parameter with no zipper. The endpoints live in whatever space you hand it
+ * (e.g. cubed), so you can lerp the cube rather than cubing the lerp. blockSize need not be a power
+ * of two.
+ */
+template <int blockSize> struct SimpleLerp
+{
+    static_assert(blockSize > 0);
+
+    // dst[s] = start + (end - start) * (s + 1) / blockSize, s in [0, blockSize)
+    static inline void fill(float start, float end, float *__restrict dst)
+    {
+        const float dv = (end - start) / blockSize;
+        for (int s = 0; s < blockSize; ++s)
+            dst[s] = start + dv * (s + 1);
+    }
+
+    // dst[s] += ramp(s) * src[s]
+    static inline void multiplyAccumulate(float start, float end, const float *__restrict src,
+                                          float *__restrict dst)
+    {
+        const float dv = (end - start) / blockSize;
+        for (int s = 0; s < blockSize; ++s)
+            dst[s] += (start + dv * (s + 1)) * src[s];
+    }
+
+    // dst[s] = ramp(s) * src[s]
+    static inline void multiply(float start, float end, const float *__restrict src,
+                                float *__restrict dst)
+    {
+        const float dv = (end - start) / blockSize;
+        for (int s = 0; s < blockSize; ++s)
+            dst[s] = (start + dv * (s + 1)) * src[s];
+    }
+};
 } // namespace sst::basic_blocks::dsp
 
 #endif // SHORTCIRCUITXT_BLOCKINTERPOLATORS_H

--- a/tests/dsp_tests.cpp
+++ b/tests/dsp_tests.cpp
@@ -146,6 +146,90 @@ TEST_CASE("lipol_sse basic", "[dsp]")
     }
 }
 
+TEST_CASE("SimpleLerp", "[dsp]")
+{
+    using sst::basic_blocks::dsp::SimpleLerp;
+
+    SECTION("fill ramps start->end with the end-of-block convention")
+    {
+        constexpr int bs{16};
+        const float start{0.2f}, end{0.6f};
+        float where alignas(16)[bs];
+        SimpleLerp<bs>::fill(start, end, where);
+        for (int i = 0; i < bs; ++i)
+            REQUIRE(where[i] == Approx(start + (end - start) / bs * (i + 1)).margin(1e-5));
+        REQUIRE(where[bs - 1] == Approx(end).margin(1e-5)); // last sample lands on end
+    }
+
+    SECTION("fill works for a non-power-of-two block")
+    {
+        constexpr int bs{6};
+        const float start{-0.3f}, end{0.9f};
+        float where alignas(16)[bs];
+        SimpleLerp<bs>::fill(start, end, where);
+        for (int i = 0; i < bs; ++i)
+            REQUIRE(where[i] == Approx(start + (end - start) / bs * (i + 1)).margin(1e-5));
+    }
+
+    SECTION("multiplyAccumulate adds ramp*src into dst")
+    {
+        constexpr int bs{32};
+        const float start{0.1f}, end{0.7f};
+        float src alignas(16)[bs], dst alignas(16)[bs], seed alignas(16)[bs];
+        for (int i = 0; i < bs; ++i)
+        {
+            src[i] = std::sin(i * 0.2 * M_PI);
+            seed[i] = 0.01f * i - 0.1f; // pre-existing content it must accumulate onto
+            dst[i] = seed[i];
+        }
+        SimpleLerp<bs>::multiplyAccumulate(start, end, src, dst);
+        for (int i = 0; i < bs; ++i)
+        {
+            auto ramp = start + (end - start) / bs * (i + 1);
+            REQUIRE(dst[i] == Approx(seed[i] + ramp * src[i]).margin(1e-5));
+        }
+    }
+
+    SECTION("multiply writes ramp*src into dst (no accumulate)")
+    {
+        constexpr int bs{8};
+        const float start{0.2f}, end{0.6f};
+        float src alignas(16)[bs], dst alignas(16)[bs];
+        for (int i = 0; i < bs; ++i)
+        {
+            src[i] = std::sin(i * 0.2 * M_PI);
+            dst[i] = 12345.f; // overwritten, not accumulated
+        }
+        SimpleLerp<bs>::multiply(start, end, src, dst);
+        for (int i = 0; i < bs; ++i)
+        {
+            auto ramp = start + (end - start) / bs * (i + 1);
+            REQUIRE(dst[i] == Approx(ramp * src[i]).margin(1e-5));
+        }
+    }
+
+    SECTION("a flat ramp is a plain constant scale (steady-state identity)")
+    {
+        // start == end must reduce to a scalar multiply — the property the block-rate mixer relies
+        // on so a constant parameter renders identically to the pre-lerp code.
+        constexpr int bs{16};
+        const float level{0.42f};
+        float src alignas(16)[bs], dst alignas(16)[bs], line alignas(16)[bs];
+        for (int i = 0; i < bs; ++i)
+        {
+            src[i] = std::sin(i * 0.37);
+            dst[i] = 0.f;
+        }
+        SimpleLerp<bs>::fill(level, level, line);
+        SimpleLerp<bs>::multiplyAccumulate(level, level, src, dst);
+        for (int i = 0; i < bs; ++i)
+        {
+            REQUIRE(line[i] == Approx(level).margin(1e-6));         // ramp is flat
+            REQUIRE(dst[i] == Approx(level * src[i]).margin(1e-6)); // == plain scalar multiply
+        }
+    }
+}
+
 TEST_CASE("lipol_sse multiply_block", "[dsp]")
 {
     SECTION("Block Size 16")


### PR DESCRIPTION
lipol sse has storage and so on. Sometimes you just want a tested loop over endpoints to multiply another block and so on and let the modern compilers unroll it for you.

Assisted-By: Claude Opus 4.8