### PR TITLE
Return nullopt instead of throwing on malformed type-ins

### DIFF
--- a/include/sst/basic-blocks/params/ParamMetadata.h
+++ b/include/sst/basic-blocks/params/ParamMetadata.h
@@ -1738,17 +1738,25 @@ inline std::optional<float> ParamMetaData::valueFromString(std::string_view v, s
         if (v == "-inf")
             return minVal;
 
-        auto r = std::stof(std::string(v));
-        // A ln(r) / ln(B) + C = v
-        // (r - c) * lnB / A = lnv
-        auto lnv = (r - svC) * std::log(svB) / svA;
-        auto res = std::exp(lnv);
-        if (res < minVal || res > maxVal)
+        try
+        {
+            auto r = std::stof(std::string(v));
+            // A ln(r) / ln(B) + C = v
+            // (r - c) * lnB / A = lnv
+            auto lnv = (r - svC) * std::log(svB) / svA;
+            auto res = std::exp(lnv);
+            if (res < minVal || res > maxVal)
+            {
+                errMsg = rangeMsg();
+                return std::nullopt;
+            }
+            return res;
+        }
+        catch (const std::exception &)
         {
             errMsg = rangeMsg();
             return std::nullopt;
         }
-        return res;
     }
     break;
 

--- a/include/sst/basic-blocks/tables/TemposyncSupport.h
+++ b/include/sst/basic-blocks/tables/TemposyncSupport.h
@@ -32,6 +32,7 @@
 #include <algorithm>
 #include <string>
 #include <optional>
+#include <limits>
 #include <cmath>
 #include <cstdio>
 #include <cctype>
@@ -166,6 +167,32 @@ inline std::string toString(const Note &n)
     return "dotted whole note";
 }
 
+namespace detail
+{
+// std::stoi throws (invalid_argument on no digits, out_of_range on overflow) but
+// fromString promises nullopt on anything unrecognized, so parse without it.
+// Mirrors stoi's prefix semantics for the character set that can reach here:
+// skip leading blanks, consume digits, stop at the first non-digit.
+inline std::optional<int> prefixToInt(const std::string &s)
+{
+    size_t i{0};
+    while (i < s.size() && s[i] == ' ')
+        ++i;
+    if (i >= s.size() || s[i] < '0' || s[i] > '9')
+        return std::nullopt;
+
+    int64_t acc{0};
+    while (i < s.size() && s[i] >= '0' && s[i] <= '9')
+    {
+        acc = acc * 10 + (s[i] - '0');
+        if (acc > std::numeric_limits<int>::max())
+            return std::nullopt;
+        ++i;
+    }
+    return (int)acc;
+}
+} // namespace detail
+
 // Parse a temposync notation string back into a Note - the inverse of toString
 // (and toStringCompact). Handles verbose words ("1/4 triplet", "whole note",
 // "dotted whole note"), compact suffixes ("1/4 T", "2W", "1W D"), and the
@@ -220,11 +247,22 @@ inline std::optional<Note> fromString(const std::string &s)
     {
         auto slpos = numPart.find('/');
         if (slpos == std::string::npos)
-            num = std::stoi(numPart);
+        {
+            auto n = detail::prefixToInt(numPart);
+            if (!n)
+                return std::nullopt;
+            num = *n;
+        }
         else
         {
-            num = std::stoi(numPart.substr(0, slpos));
-            den = std::stoi(numPart.substr(slpos + 1));
+            // hasDigit only proves a digit somewhere in numPart, not on both sides
+            // of the slash, so "1/" and "/4" can still arrive with an empty side.
+            auto n = detail::prefixToInt(numPart.substr(0, slpos));
+            auto d = detail::prefixToInt(numPart.substr(slpos + 1));
+            if (!n || !d)
+                return std::nullopt;
+            num = *n;
+            den = *d;
         }
     }
     else if (!hasWhole) // no number and not a bare "whole ..." form

--- a/tests/param_tests.cpp
+++ b/tests/param_tests.cpp
@@ -599,6 +599,67 @@ TEST_CASE("Temposync type In")
     }
 }
 
+TEST_CASE("Malformed type-in returns nullopt rather than throwing")
+{
+    // valueFromString hands back a std::optional, so input it cannot parse has to
+    // come back as nullopt. Every float display scale wraps its std::stof for that
+    // reason except LOGARITHMIC, which let std::invalid_argument escape to the
+    // caller - and an empty field is the easy way to hit it.
+    auto lg = pmd::ParamMetaData().asFloat().withRange(0.1f, 100.f).withLogarithmicFormating("Hz");
+    auto ln = pmd::ParamMetaData().asFloat().withRange(0.f, 1.f).withLinearScaleFormatting("x");
+
+    for (const auto &bad : {std::string("banana"), std::string(""), std::string("   ")})
+    {
+        DYNAMIC_SECTION("LOGARITHMIC rejects '" << bad << "'")
+        {
+            std::string em;
+            std::optional<float> r;
+            REQUIRE_NOTHROW(r = lg.valueFromString(bad, em));
+            REQUIRE(!r.has_value());
+        }
+
+        // the sibling scale already behaved; keep it honest that we match it
+        DYNAMIC_SECTION("LINEAR rejects '" << bad << "'")
+        {
+            std::string em;
+            std::optional<float> r;
+            REQUIRE_NOTHROW(r = ln.valueFromString(bad, em));
+            REQUIRE(!r.has_value());
+        }
+    }
+
+    SECTION("well formed input still parses")
+    {
+        std::string em;
+        REQUIRE(lg.valueFromString("10", em).has_value());
+    }
+}
+
+TEST_CASE("Malformed temposync notation returns nullopt rather than throwing")
+{
+    auto p = pmd::ParamMetaData().asLfoRate();
+
+    // A digit anywhere in the numeric part is not a digit on both sides of the
+    // slash, so a half-typed fraction reached std::stoi with an empty side, and a
+    // long run of digits overflowed int. "1/" is simply what is on screen partway
+    // through typing "1/4".
+    for (const auto &bad : {std::string("1/"), std::string("/4"), std::string("999999999999"),
+                            std::string("1/999999999999")})
+    {
+        DYNAMIC_SECTION("rejects '" << bad << "'")
+        {
+            std::optional<float> v;
+            REQUIRE_NOTHROW(v = p.valueFromTemposyncNotation(bad));
+            REQUIRE(!v.has_value());
+        }
+    }
+
+    SECTION("the well formed neighbour still parses")
+    {
+        REQUIRE(p.valueFromTemposyncNotation("1/4").has_value());
+    }
+}
+
 TEST_CASE("Temposync ZERO_ONE flavor dispatch")
 {
     namespace ts = sst::basic_blocks::tables::temposync;


### PR DESCRIPTION
`valueFromString` and `valueFromTemposyncNotation` both hand back a `std::optional`, so input they can't parse is supposed to come back as `nullopt`. Two paths let an exception escape to the caller instead. Both are reachable by typing into an ordinary parameter field.

### `ParamMetadata.h` — the LOGARITHMIC scale

Every float display scale wraps its `std::stof` so a bad type-in turns into `nullopt`. `LOGARITHMIC` called it bare, so anything unparseable threw `std::invalid_argument` out of the function. An empty field does it — select all, delete, return.

```
LOGARITHMIC  "banana" -> *** THREW: stof: no conversion ***
LOGARITHMIC  ""       -> *** THREW: stof: no conversion ***
LINEAR       "banana" -> nullopt          <- the sibling scales were already fine
```

Fixed by wrapping in the same `try`/`catch` the neighbouring cases use, setting `errMsg = rangeMsg()` exactly as they do.

### `TemposyncSupport.h` — `fromString`

`hasDigit` proves a digit appears somewhere in the numeric part. That isn't the same as a digit on *both* sides of the slash, so `"1/"` and `"/4"` reached `std::stoi("")` and threw. A long digit run threw `out_of_range` too. `"1/"` is simply what's on screen partway through typing `"1/4"`.

```
temposync "1/"            -> *** THREW: stoi: no conversion ***
temposync "/4"            -> *** THREW: stoi: no conversion ***
temposync "999999999999"  -> *** THREW: stoi: out of range ***
temposync "1/4"           -> value        <- unchanged
```

Parsing now goes through a small `detail::prefixToInt` that mirrors `stoi`'s prefix semantics for the characters that can actually reach it (blanks then digits, stop at the first non-digit) and reports failure instead of throwing.

### Testing

Two cases added to `tests/param_tests.cpp`, using `REQUIRE_NOTHROW` so they fail on the exception itself rather than on a comparison.

I checked they fail without the fix rather than only passing with it. Reverting both headers and keeping the tests gives:

```
test cases:  2 | 2 failed
assertions: 15 | 8 passed | 7 failed
due to unexpected exception with message: stoi: no conversion
due to unexpected exception with message: stoi: out of range
```

With the fix the full runner is green: **2039800 assertions in 75 test cases**. `clang-format` clean on all three files.

One note on scope: I found these while reading `ParamMetadata.h` for the locale type-in work in surge-synthesizer/surge#8522. They're independent of that, and small enough to stand alone, so I've kept them separate rather than folding them in.

---

Assisted-By: Claude Code (Claude Opus 5) — I used it to trace the call sites and draft the patch; the analysis, the both-ways check and the review of it are mine.

X: [@manuaudiomix](https://x.com/manuaudiomix)
